### PR TITLE
fix(accounts): Prevent stale slot reuse during account creation

### DIFF
--- a/redfish/src/account/collection.rs
+++ b/redfish/src/account/collection.rs
@@ -185,6 +185,21 @@ impl<B: Bmc> AccountCollection<B> {
                     // Slot is already explicitly enabled. Find another slot.
                     continue;
                 }
+
+                // Expanded collection members are a snapshot. Re-fetch the
+                // candidate immediately before updating it so concurrent
+                // account creation cannot reuse stale slot state.
+                let fresh_nav = NavProperty::new_reference(account.raw().odata_id().clone());
+                let Ok(account) = Account::new(&self.bmc, &fresh_nav, &self.config.account).await
+                else {
+                    continue;
+                };
+                if account.is_enabled() || account.raw().etag().is_none() {
+                    // Without a fresh ETag, the HTTP BMC would fall back to an
+                    // unconditional `If-Match: *` update.
+                    continue;
+                }
+
                 // Build an update based on the create request:
                 let update = ManagerAccountUpdate {
                     base: None,

--- a/redfish/src/account/collection.rs
+++ b/redfish/src/account/collection.rs
@@ -188,17 +188,18 @@ impl<B: Bmc> AccountCollection<B> {
 
                 // Expanded collection members are a snapshot. Re-fetch the
                 // candidate immediately before updating it so concurrent
-                // account creation cannot reuse stale slot state.
-                let fresh_nav = NavProperty::new_reference(account.raw().odata_id().clone());
-                let Ok(account) = Account::new(&self.bmc, &fresh_nav, &self.config.account).await
-                else {
+                // account creation cannot reuse stale slot state. Require a
+                // fresh ETag so the HTTP BMC cannot fall back to `If-Match: *`.
+                let Some(account) = Account::new(
+                    &self.bmc,
+                    &NavProperty::new_reference(account.raw().odata_id().clone()),
+                    &self.config.account,
+                )
+                .await
+                .ok()
+                .filter(|a| !a.is_enabled() && a.raw().etag().is_some()) else {
                     continue;
                 };
-                if account.is_enabled() || account.raw().etag().is_none() {
-                    // Without a fresh ETag, the HTTP BMC would fall back to an
-                    // unconditional `If-Match: *` update.
-                    continue;
-                }
 
                 // Build an update based on the create request:
                 let update = ManagerAccountUpdate {

--- a/tests/tests/tests-account-service.rs
+++ b/tests/tests/tests-account-service.rs
@@ -243,8 +243,14 @@ async fn get_account_collection(
     Ok(account_service.accounts().await.map(Option::unwrap)?)
 }
 
-fn slot_member(accounts_id: &str, id: u32, enabled: bool, user_name: &str) -> JsonValue {
-    json!({
+fn slot_member(
+    accounts_id: &str,
+    id: u32,
+    enabled: bool,
+    user_name: &str,
+    etag: Option<&str>,
+) -> JsonValue {
+    let mut member = json!({
         ODATA_ID: format!("{accounts_id}/{id}"),
         ODATA_TYPE: MANAGER_ACCOUNT_DATA_TYPE,
         "Id": id.to_string(),
@@ -252,20 +258,11 @@ fn slot_member(accounts_id: &str, id: u32, enabled: bool, user_name: &str) -> Js
         "Enabled": enabled,
         "AccountTypes": [],
         "UserName": user_name,
-    })
-}
-
-fn slot_member_with_etag(
-    accounts_id: &str,
-    id: u32,
-    enabled: bool,
-    user_name: &str,
-    etag: &str,
-) -> JsonValue {
-    json_merge([
-        &slot_member(accounts_id, id, enabled, user_name),
-        &json!({ "@odata.etag": etag }),
-    ])
+    });
+    if let Some(etag) = etag {
+        member["@odata.etag"] = JsonValue::String(etag.to_string());
+    }
+    member
 }
 
 async fn account_fixture(
@@ -280,7 +277,9 @@ async fn account_fixture(
     let members = JsonValue::Array(
         slots
             .iter()
-            .map(|&(id, enabled, user_name)| slot_member(&accounts_id, id, enabled, user_name))
+            .map(|&(id, enabled, user_name)| {
+                slot_member(&accounts_id, id, enabled, user_name, None)
+            })
             .collect(),
     );
 
@@ -437,14 +436,14 @@ async fn create_account_dell_slot_defined_first_available() -> TestResult<()> {
 
     bmc.expect(Expect::get(
         &account_id,
-        slot_member_with_etag(&accounts_id, 3, false, "", etag),
+        slot_member(&accounts_id, 3, false, "", Some(etag)),
     ));
 
     bmc.expect(Expect::update(
         &account_id,
         update_json,
         json_merge([
-            &slot_member(&accounts_id, 3, true, "user"),
+            &slot_member(&accounts_id, 3, true, "user", None),
             &json! {{"RoleId": "Operator"}},
         ]),
     ));
@@ -471,17 +470,17 @@ async fn create_account_slot_defined_rechecks_stale_candidate() -> TestResult<()
 
     bmc.expect(Expect::get(
         &stale_account_id,
-        slot_member_with_etag(&accounts_id, 3, true, "another-user", "slot-3-v2"),
+        slot_member(&accounts_id, 3, true, "another-user", Some("slot-3-v2")),
     ));
     bmc.expect(Expect::get(
         &available_account_id,
-        slot_member_with_etag(&accounts_id, 4, false, "", etag),
+        slot_member(&accounts_id, 4, false, "", Some(etag)),
     ));
     bmc.expect(Expect::update(
         &available_account_id,
         update_json,
         json_merge([
-            &slot_member(&accounts_id, 4, true, "user"),
+            &slot_member(&accounts_id, 4, true, "user", None),
             &json! {{ "RoleId": "Operator" }},
         ]),
     ));
@@ -501,7 +500,7 @@ async fn create_account_slot_defined_requires_etag() -> TestResult<()> {
 
     bmc.expect(Expect::get(
         &account_id,
-        slot_member(&accounts_id, 3, false, ""),
+        slot_member(&accounts_id, 3, false, "", None),
     ));
 
     assert!(matches!(
@@ -524,7 +523,7 @@ async fn create_account_slot_defined_preserves_async_task() -> TestResult<()> {
 
     bmc.expect(Expect::get(
         &account_id,
-        slot_member_with_etag(&accounts_id, 3, false, "", "slot-3-v1"),
+        slot_member(&accounts_id, 3, false, "", Some("slot-3-v1")),
     ));
 
     bmc.expect(Expect::update_task(

--- a/tests/tests/tests-account-service.rs
+++ b/tests/tests/tests-account-service.rs
@@ -255,6 +255,19 @@ fn slot_member(accounts_id: &str, id: u32, enabled: bool, user_name: &str) -> Js
     })
 }
 
+fn slot_member_with_etag(
+    accounts_id: &str,
+    id: u32,
+    enabled: bool,
+    user_name: &str,
+    etag: &str,
+) -> JsonValue {
+    json_merge([
+        &slot_member(accounts_id, id, enabled, user_name),
+        &json!({ "@odata.etag": etag }),
+    ])
+}
+
 async fn account_fixture(
     vendor: &str,
     slots: &[(u32, bool, &str)],
@@ -419,9 +432,16 @@ async fn create_account_dell_slot_defined_first_available() -> TestResult<()> {
 
     let update_req = slot_update();
     let update_json = serde_json::to_value(&update_req).unwrap();
+    let account_id = format!("{accounts_id}/3");
+    let etag = "slot-3-v1";
+
+    bmc.expect(Expect::get(
+        &account_id,
+        slot_member_with_etag(&accounts_id, 3, false, "", etag),
+    ));
 
     bmc.expect(Expect::update(
-        format!("{accounts_id}/3"),
+        &account_id,
         update_json,
         json_merge([
             &slot_member(&accounts_id, 3, true, "user"),
@@ -440,6 +460,59 @@ async fn create_account_dell_slot_defined_first_available() -> TestResult<()> {
 }
 
 #[test]
+async fn create_account_slot_defined_rechecks_stale_candidate() -> TestResult<()> {
+    let (bmc, accounts_id, accounts) =
+        account_fixture("Dell", &[(3, false, ""), (4, false, "")]).await?;
+    let update_req = slot_update();
+    let update_json = serde_json::to_value(&update_req).unwrap();
+    let stale_account_id = format!("{accounts_id}/3");
+    let available_account_id = format!("{accounts_id}/4");
+    let etag = "slot-4-v1";
+
+    bmc.expect(Expect::get(
+        &stale_account_id,
+        slot_member_with_etag(&accounts_id, 3, true, "another-user", "slot-3-v2"),
+    ));
+    bmc.expect(Expect::get(
+        &available_account_id,
+        slot_member_with_etag(&accounts_id, 4, false, "", etag),
+    ));
+    bmc.expect(Expect::update(
+        &available_account_id,
+        update_json,
+        json_merge([
+            &slot_member(&accounts_id, 4, true, "user"),
+            &json! {{ "RoleId": "Operator" }},
+        ]),
+    ));
+
+    let account = into_entity(accounts.create_account(create_request("user")).await?).raw();
+
+    assert_eq!(account.base.id, "4");
+    assert_eq!(account.user_name.as_deref(), Some("user"));
+
+    Ok(())
+}
+
+#[test]
+async fn create_account_slot_defined_requires_etag() -> TestResult<()> {
+    let (bmc, accounts_id, accounts) = account_fixture("Dell", &[(3, false, "")]).await?;
+    let account_id = format!("{accounts_id}/3");
+
+    bmc.expect(Expect::get(
+        &account_id,
+        slot_member(&accounts_id, 3, false, ""),
+    ));
+
+    assert!(matches!(
+        accounts.create_account(create_request("user")).await,
+        Err(nv_redfish::Error::AccountSlotNotAvailable)
+    ));
+
+    Ok(())
+}
+
+#[test]
 async fn create_account_slot_defined_preserves_async_task() -> TestResult<()> {
     let (bmc, accounts_id, accounts) =
         account_fixture("Dell", &[(1, true, "root"), (3, false, "")]).await?;
@@ -448,6 +521,11 @@ async fn create_account_slot_defined_preserves_async_task() -> TestResult<()> {
     let update_json = serde_json::to_value(&update_req).unwrap();
     let account_id = format!("{accounts_id}/3");
     let task_id = "/redfish/v1/TaskService/Tasks/43";
+
+    bmc.expect(Expect::get(
+        &account_id,
+        slot_member_with_etag(&accounts_id, 3, false, "", "slot-3-v1"),
+    ));
 
     bmc.expect(Expect::update_task(
         &account_id,


### PR DESCRIPTION
## What changed

- Re-fetch a slot-defined account immediately before enabling it instead of relying on the expanded collection snapshot.
- Require the fresh account to remain disabled and carry an ETag before issuing the update, so the HTTP path cannot fall back to `If-Match: *` for slot creation.
- Add regressions for a candidate that became enabled after collection expansion and for a disabled candidate without an ETag.

## Why

Concurrent creators could select the same disabled slot from the collection snapshot. If the snapshot did not carry an ETag, the second update became unconditional and could overwrite the first account's credentials.

The fresh read plus conditional update closes that race: a slot already claimed is skipped, while concurrent updates against the same fresh ETag let the BMC reject the stale writer.

## Validation

- Before the production change, `create_account_slot_defined_rechecks_stale_candidate` failed because the code issued an update for slot 3 before the expected fresh GET.
- `cargo test -p nv-redfish-tests --test tests-account-service` (15 passed)
- `cargo test -p nv-redfish-tests --tests` (all integration and trybuild targets passed)
- `cargo test -p nv-redfish --features accounts`
- `cargo test -p nv-redfish-bmc-http --test reqwest_client_tests --features reqwest test_patch_update_request`
- `cargo fmt --all -- --check`
- `cargo clippy -p nv-redfish --features accounts -- -D warnings`
- `cargo clippy -p nv-redfish-tests --test tests-account-service -- -D warnings`

The checks ran with Rust 1.90.0 in a Linux arm64 container. A physical Dell BMC was not available, so this remains a draft pending maintainer review or hardware-backed verification.

Resolves #141
