### PR TITLE
fix(csdl-compiler): keep AdditionalProperties when folding a base type

### DIFF
--- a/csdl-compiler/src/optimizer/prune_complex_type_inheritance.rs
+++ b/csdl-compiler/src/optimizer/prune_complex_type_inheritance.rs
@@ -84,9 +84,20 @@ pub fn prune_complex_type_inheritance<'a>(input: Compiled<'a>, _config: &Config)
         // Pass all properties from single child parents to child.
         .map(|(name, v)| {
             let mut base = v.base;
+            let mut odata = v.odata;
             let mut properties = vec![v.properties];
             while let Some(next_base) = base {
                 if let Some(parent) = remove.remove(&next_base) {
+                    // `OData.AdditionalProperties` also governs the
+                    // types deriving from the one declaring it, so
+                    // folding a parent away must carry the permission
+                    // over. Losing it would silently drop every
+                    // undeclared property the payload carries. A type
+                    // stating its own permission keeps it; the nearest
+                    // ancestor that states one wins otherwise.
+                    if odata.additional_properties.is_none() {
+                        odata.additional_properties = parent.odata.additional_properties;
+                    }
                     properties.push(parent.properties);
                     base = parent.base;
                 } else {
@@ -99,7 +110,7 @@ pub fn prune_complex_type_inheritance<'a>(input: Compiled<'a>, _config: &Config)
                     name: v.name,
                     base,
                     properties: Properties::rev_join(properties),
-                    odata: v.odata,
+                    odata,
                     redfish: v.redfish,
                     is_abstract: v.is_abstract,
                 },

--- a/csdl-compiler/src/optimizer/prune_entity_type_inheritance.rs
+++ b/csdl-compiler/src/optimizer/prune_entity_type_inheritance.rs
@@ -146,6 +146,9 @@ fn merge_odata<'a>(odata: &mut OData<'a>, parent_odata: OData<'a>) {
     if !odata.must_have_type.inner() {
         odata.must_have_type = parent_odata.must_have_type;
     }
+    if odata.additional_properties.is_none() {
+        odata.additional_properties = parent_odata.additional_properties;
+    }
     if odata.description.is_none() {
         odata.description = parent_odata.description;
     }

--- a/tests/tests/test-service-root-oem-ami.rs
+++ b/tests/tests/test-service-root-oem-ami.rs
@@ -51,6 +51,39 @@ async fn service_root_ami_rtp_version_parsed() -> Result<(), Box<dyn StdError>> 
 }
 
 #[test]
+async fn service_root_ami_undeclared_oem_properties_retained() -> Result<(), Box<dyn StdError>> {
+    // `AMIServiceRoot` declares no `OData.AdditionalProperties` of its
+    // own and derives from `Resource.OemObject`, which permits them, so
+    // properties the schema does not name must still be readable. The
+    // optimizer folds that sole-child base away, and dropping its
+    // permission while doing so would silently discard them here.
+    let bmc = Arc::new(Bmc::default());
+    let root = get_root(
+        bmc.clone(),
+        root_payload(Some(json!({
+            ODATA_TYPE: AMI_SERVICE_ROOT_DATA_TYPE,
+            "RtpVersion": "13.09.1",
+            "UndeclaredBySchema": "kept",
+        }))),
+    )
+    .await?;
+
+    let ami = root
+        .oem_ami_service_root()?
+        .expect("AMI ServiceRoot OEM extension should be present");
+    assert_eq!(ami.rtp_version(), Some("13.09.1"));
+    assert_eq!(
+        ami.raw()
+            .additional_properties
+            .get("UndeclaredBySchema")
+            .and_then(serde_json::Value::as_str),
+        Some("kept"),
+    );
+
+    Ok(())
+}
+
+#[test]
 async fn service_root_without_ami_oem_returns_none() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let root = get_root(bmc.clone(), root_payload(None)).await?;


### PR DESCRIPTION
The inheritance pruners fold a base complex/entity type into its child when the base has exactly one child, but the complex-type pruner kept only the child's own OData annotations and dropped the parent's. A type that declares no `OData.AdditionalProperties` of its own therefore lost the permission it inherits from an open base, and silently stopped collecting undeclared properties.

Because the fold only triggers on a sole child, whether this happened depended on how many unrelated sibling types were compiled, so the same type deserialized differently between feature sets.

The child now inherits the folded parent's permission when it states none itself; an explicit `false` still wins. Corpus-wide exactly one type is affected, `AMIServiceRoot`, which regains its catch-all.