### PR TITLE
fix(redfish): resolve network schema dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ define build-and-test
 	cargo build -p nv-redfish --features managers,oem-supermicro
 	cargo build -p nv-redfish --features chassis,power-supplies,oem-liteon
 	cargo build -p nv-redfish --features chassis,controls
+	cargo build -p nv-redfish --features chassis,network-adapters
+	cargo build -p nv-redfish --features chassis,network-adapters,network-device-functions
 	cargo build
 	cargo build -p nv-redfish
 	cargo build -p nv-redfish-tests --tests

--- a/redfish/features.toml
+++ b/redfish/features.toml
@@ -129,7 +129,8 @@ patterns = [
 name = "network-adapters"
 csdl_files = [
     "NetworkAdapterCollection_v1.xml",
-    "NetworkAdapter_v1.xml"
+    "NetworkAdapter_v1.xml",
+    "PCIeDevice_v1.xml",
 ]
 patterns = [
     "NetworkAdapterCollection.*",
@@ -142,6 +143,7 @@ csdl_files = [
     "NetworkDeviceFunctionCollection_v1.xml",
     "NetworkDeviceFunction_v1.xml",
     "Protocol_v1.xml",
+    "VLanNetworkInterface_v1.xml",
 ]
 patterns = [
     "NetworkDeviceFunctionCollection.*",


### PR DESCRIPTION
Fix hidden schema dependencies in network feature combinations.

**Minimal repro**

Before this change:

```bash
cargo build -p nv-redfish --features chassis,network-adapters
cargo build -p nv-redfish --features chassis,network-adapters,network-device-functions
```

Both builds fail because referenced schema types are not generated.