### PR TITLE
fix(bmc-http): require sse-stream 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ categories = ["hardware-support"]
 [workspace.dependencies]
 clap = { version = "4.5" }
 clap_derive = { version = "4.5" }
-sse-stream = { version = "0.2.1" }
+sse-stream = { version = "0.2.4" }
 bytes = { version = "1" }
 futures-util = { version = "0.3" }
 futures-core = { version = "0.3" }


### PR DESCRIPTION
Found this issue when I had an older Cargo.lock file and it pinned `0.2.3`, and Cargo.toml required `0.2.1` which allowed `>=0.2.1, <0.3.0`.

The issue was caused by the use of `from_bytes_stream` which was introduced in `sse-stream 0.2.4`. So it's probably a good idea to require `0.2.4` in Cargo.toml.