### PR TITLE
fix: preserve BlueField OEM and port collection data

### DIFF
--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -64,7 +64,10 @@ impl BmcQuirks {
             Some("NVIDIA") if product_str == Some("VR NVL72") => Some(Platform::VeraRubin),
             Some("NVIDIA") if product_str == Some("P3809") => Some(Platform::NvSwitch),
             Some("NVIDIA") => Some(Platform::Nvidia),
-            Some("Nvidia") if product_str == Some("Nvidia-BMCMezz") => Some(Platform::NvidiaDpu),
+            // BF3 service roots use this product name with an `Nvidia` vendor.
+            Some("Nvidia") if matches!(product_str, Some("Nvidia-BMCMezz" | "BlueField-3 DPU")) => {
+                Some(Platform::NvidiaDpu)
+            }
             None if redfish_version_str == Some("1.9.0") => Some(Platform::Anonymous1_9_0),
             _ => None,
         };

--- a/redfish/src/port/collection.rs
+++ b/redfish/src/port/collection.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use super::Port;
+use super::PortLink;
 use crate::schema::port_collection::PortCollection as PortCollectionSchema;
 use crate::Error;
 use crate::NvBmc;
@@ -52,5 +53,18 @@ impl<B: Bmc> PortCollection<B> {
             members.push(Port::new(&self.bmc, member).await?);
         }
         Ok(members)
+    }
+
+    /// Return lazy links for the ports in this collection.
+    ///
+    /// Each link can be fetched independently, allowing callers to choose their own error-handling
+    /// policy without changing the eager, all-or-nothing behavior of [`Self::members`].
+    #[must_use]
+    pub fn member_links(&self) -> Vec<PortLink<B>> {
+        self.collection
+            .members
+            .iter()
+            .map(|member| PortLink::new(&self.bmc, NavProperty::new_reference(member.id().clone())))
+            .collect()
     }
 }

--- a/redfish/src/port/item.rs
+++ b/redfish/src/port/item.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::entity_link::EntityLink;
+use crate::entity_link::FromLink;
 use crate::mac_address::MacAddress;
 use crate::schema::port::Port as PortSchema;
 use crate::Error;
@@ -21,11 +23,15 @@ use crate::Resource;
 use crate::ResourceSchema;
 use nv_redfish_core::Bmc;
 use nv_redfish_core::NavProperty;
+use std::future::Future;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 #[cfg(feature = "oem-lenovo")]
 use crate::oem::lenovo::port::LenovoPort;
+
+/// Link for lazily accessing a network port.
+pub type PortLink<B> = EntityLink<B, PortSchema>;
 
 /// Network port.
 pub struct Port<B: Bmc> {
@@ -90,5 +96,16 @@ impl<B: Bmc> Port<B> {
 impl<B: Bmc> Resource for Port<B> {
     fn resource_ref(&self) -> &ResourceSchema {
         &self.data.as_ref().base
+    }
+}
+
+impl<B: Bmc> FromLink<B> for Port<B> {
+    type Schema = PortSchema;
+
+    fn from_link(
+        bmc: &NvBmc<B>,
+        nav: &NavProperty<Self::Schema>,
+    ) -> impl Future<Output = Result<Self, Error<B>>> + Send {
+        Self::new(bmc, nav)
     }
 }

--- a/redfish/src/port/mod.rs
+++ b/redfish/src/port/mod.rs
@@ -22,3 +22,5 @@ mod item;
 pub use collection::PortCollection;
 #[doc(inline)]
 pub use item::Port;
+#[doc(inline)]
+pub use item::PortLink;

--- a/tests/tests/test-computer-system-oem-nvidia.rs
+++ b/tests/tests/test-computer-system-oem-nvidia.rs
@@ -37,6 +37,7 @@ const NVIDIA_SYSTEM_DATA_TYPE: &str = "#NvidiaComputerSystem.v1_0_0.NvidiaComput
 /// Service-root identity of an NVIDIA DPU.
 const DPU_VENDOR: &str = "Nvidia";
 const DPU_PRODUCT: &str = "Nvidia-BMCMezz";
+const BF3_DPU_PRODUCT: &str = "BlueField-3 DPU";
 
 #[test]
 async fn oem_nvidia_dpu_missing_odata_id_in_oem_target_payload() -> Result<(), Box<dyn StdError>> {
@@ -115,6 +116,49 @@ async fn oem_nvidia_dpu_with_odata_id_still_supported() -> Result<(), Box<dyn St
         Some("aabbccddeeff".into())
     );
     assert_eq!(oem.mode(), Some(Mode::DpuMode));
+
+    Ok(())
+}
+
+#[test]
+async fn oem_nvidia_bluefield3_product_fetches_oem_target() -> Result<(), Box<dyn StdError>> {
+    // Platform under test: NVIDIA BlueField-3 DPU using its product name.
+    // Quirk under test: the BF3 product identity selects NVIDIA DPU handling.
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let system = get_system_on_platform(
+        bmc.clone(),
+        &ids,
+        system_payload(
+            &ids,
+            Some(json!({
+                "Nvidia": { ODATA_ID: &ids.nvidia_oem_id }
+            })),
+        ),
+        DPU_VENDOR,
+        BF3_DPU_PRODUCT,
+    )
+    .await?;
+
+    bmc.expect(Expect::get(
+        &ids.nvidia_oem_id,
+        json!({
+            ODATA_ID: &ids.nvidia_oem_id,
+            ODATA_TYPE: NVIDIA_SYSTEM_DATA_TYPE,
+            "BaseMAC": "aabbccddeeff",
+            "Mode": "NicMode",
+        }),
+    ));
+
+    let oem = system
+        .oem_nvidia()
+        .await?
+        .expect("NVIDIA OEM extension must be available");
+    assert_eq!(
+        oem.base_mac().map(|v| v.to_string()),
+        Some("aabbccddeeff".into())
+    );
+    assert_eq!(oem.mode(), Some(Mode::NicMode));
 
     Ok(())
 }

--- a/tests/tests/test-network-adapter-port.rs
+++ b/tests/tests/test-network-adapter-port.rs
@@ -186,6 +186,72 @@ async fn malformed_lenovo_port_does_not_hide_standard_mac_address() -> Result<()
 }
 
 #[test]
+async fn member_links_allow_independent_port_fetches() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = Ids::new();
+    let adapter = get_adapter(bmc.clone(), &ids, true).await?;
+    let port_ids = &ids.port_ids[..3];
+    bmc.expect(Expect::get(
+        &ids.ports_id,
+        collection_payload(&ids.ports_id, PORT_COLLECTION_DATA_TYPE, port_ids),
+    ));
+    let collection = adapter
+        .ports()
+        .await?
+        .expect("adapter must include a port collection");
+
+    bmc.expect(Expect::get(
+        &port_ids[0],
+        port_payload(
+            &port_ids[0],
+            json!({
+                "Ethernet": {
+                    "AssociatedMACAddresses": ["10:00:00:00:00:01"]
+                }
+            }),
+        ),
+    ));
+    bmc.expect(Expect::get(&port_ids[1], json!({})));
+    bmc.expect(Expect::get(
+        &port_ids[2],
+        port_payload(
+            &port_ids[2],
+            json!({
+                "Ethernet": {
+                    "AssociatedMACAddresses": ["30:00:00:00:00:01"]
+                }
+            }),
+        ),
+    ));
+
+    let links = collection.member_links();
+    assert_eq!(links.len(), 3);
+    assert_eq!(
+        links[0]
+            .upgrade::<nv_redfish::port::Port<Bmc>>()
+            .await?
+            .associated_mac_addresses()[0]
+            .as_str(),
+        "10:00:00:00:00:01"
+    );
+    assert_eq!(links[1].odata_id().to_string(), port_ids[1]);
+    assert!(links[1]
+        .upgrade::<nv_redfish::port::Port<Bmc>>()
+        .await
+        .is_err());
+    assert_eq!(
+        links[2]
+            .upgrade::<nv_redfish::port::Port<Bmc>>()
+            .await?
+            .associated_mac_addresses()[0]
+            .as_str(),
+        "30:00:00:00:00:01"
+    );
+
+    Ok(())
+}
+
+#[test]
 async fn adapter_without_ports_link_returns_none() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let ids = Ids::new();


### PR DESCRIPTION
nv-redfish callers should be able to keep the BF3 OEM inventory and valid NetworkAdapter Ports they need when the surrounding Redfish inventory is only partially usable.

The v0.13 OEM fetch path depends on NVIDIA DPU platform detection, but infra-controller's BF3 service-root identity uses `Vendor=Nvidia`, `Product=BlueField-3 DPU`. Without recognizing that signature, the linked OEM payload is not fetched and its `BaseMAC` and `Mode` disappear. This extends the existing NVIDIA DPU quirk to that exact BF3 product identity.

Port collections have a similar all-or-nothing problem for callers that want best-effort inventory: `members()` stops at the first failed member and cannot return earlier successes. This adds a separate `member_links()` API using `EntityLink`, allowing consumers to fetch and handle each Port independently while leaving the existing `members()` behavior unchanged.

Tests added!

This supports https://github.com/NVIDIA/nv-redfish/issues/184

This also supports https://github.com/NVIDIA/infra-controller/issues/4469
