### PR TITLE
chore(rust): add toolchain.toml file

### DIFF
--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -34,7 +34,6 @@
     clippy::print_stderr
 )]
 #![allow(clippy::doc_markdown)]
-#![allow(clippy::duration_suboptimal_units)]
 #![deny(missing_docs)]
 
 //! HTTP implementation of [`nv_redfish_core::Bmc`] trait.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.90.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Add a toolchain.toml file so the lints and fmt are aligned with CI pinned Rust 1.90.0 for local dev and tests. This became noticeable since Rust 1.97.

Also removed the long-lived unknown `allow(clippy::duration_suboptimal_units)` which has been producing warnings in CI.