### PR TITLE
feat(bmc-http): add support for concurrency limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ keywords = ["rust", "redfish", "bmc"]
 categories = ["hardware-support"]
 
 [workspace.dependencies]
+async-lock = { version = "3.4" }
 clap = { version = "4.5" }
 clap_derive = { version = "4.5" }
 sse-stream = { version = "0.2.4" }

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ std-not-standalone-features = assembly \
 
 std-standalone-features = $(filter-out $(std-not-standalone-features),$(all-std-features))
 
-ci-features-list := $(subst $(space),$(comma),$(all-std-features))
+ci-features-list := $(subst $(space),$(comma),$(all-std-features)),http-extras
 
 # Feature sets whose only job is to prove the configuration type checks.
 # Nothing downstream consumes the artifacts, so they run under `cargo check`:
@@ -78,6 +78,7 @@ compile-only-feature-sets = computer-systems,processors,controls \
              chassis,network-adapters,network-device-functions \
              update-service-deprecated \
              bmc-http,update-service-deprecated \
+             http-extras \
              computer-systems,bios,boot-options,storages,memory,processors \
              oem-hpe,accounts \
              oem-hpe \
@@ -104,6 +105,7 @@ define build-and-test
 	$(foreach f,$(compile-only-feature-sets),$(call check-one-feature,$f))
 	$(maybe-lenovo-check)
 	cargo check -p nv-redfish
+	cargo check -p nv-redfish-bmc-http --no-default-features --features http-extras
 	cargo check -p nv-redfish-tests --tests
 	cargo check -p nv-redfish-bmc-mock
 	cargo build -p update-multipart --features update-service-deprecated

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ your client needs, or use `std-redfish` for a broad standard Redfish build.
 Common feature groups:
 
 - `bmc-http`: re-export `nv-redfish-bmc-http` from `nv_redfish::bmc_http`.
+- `http-extras`: enable optional HTTP client capabilities, including per-BMC operation concurrency limits; implies `bmc-http`.
 - `std-redfish`: enable a broad standard Redfish surface.
 - Service features: `accounts`, `assembly`, `bios`, `boot-options`,
   `chassis`, `computer-systems`, `ethernet-interfaces`, `event-service`,

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:ss
 update-service-deprecated = ["nv-redfish-core/update-service-deprecated"]
 
 [dependencies]
+async-lock = { workspace = true }
 bytes = { workspace = true, optional = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true, optional = true }
@@ -45,7 +46,7 @@ nv-redfish-csdl-compiler = { workspace = true }
 nv-redfish-schema = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "net", "io-util"] }
+tokio = { workspace = true, features = ["macros", "rt", "net", "io-util", "sync"] }
 tokio-test = { workspace = true }
 wiremock = { workspace = true }
 

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -15,10 +15,11 @@ default = ["reqwest"]
 
 # HTTP client implementations with reqwest
 reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:sse-stream", "dep:tokio-util", "dep:tokio", "dep:bytes"]
+http-extras = ["dep:async-lock"]
 update-service-deprecated = ["nv-redfish-core/update-service-deprecated"]
 
 [dependencies]
-async-lock = { workspace = true }
+async-lock = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true, optional = true }

--- a/bmc-http/src/concurrency.rs
+++ b/bmc-http/src/concurrency.rs
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use crate::{BmcCredentials, CacheableError, HttpBmc, HttpClient};
+
+use nv_redfish_core::query::ExpandQuery;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish_core::HttpPushUriUpdateRequest;
+use nv_redfish_core::{
+    Action, Bmc, BoxTryStream, EntityTypeRef, Expandable, FilterQuery, ModificationResponse,
+    MultipartUpdateRequest, ODataETag, ODataId, SessionCreateResponse, UploadReader,
+};
+
+use async_lock::Semaphore;
+use serde::{Deserialize, Serialize};
+
+/// Limits the number of concurrent operations entering an inner BMC.
+///
+/// Each wrapper owns independent capacity. Construct separate wrappers around
+/// BMC endpoints that share an HTTP client to retain independent endpoint
+/// limits while allowing the HTTP client to share its connection pool.
+///
+/// A permit covers the complete inner [`Bmc`] operation, including transport
+/// retries. Stream operations release their permit after connection
+/// establishment, so the returned stream does not consume capacity.
+/// Capacity waits are asynchronous, and canceling a waiting operation does not
+/// consume a permit.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # #[cfg(feature = "reqwest")]
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::num::NonZeroUsize;
+///
+/// use nv_redfish_bmc_http::reqwest::Client;
+/// use nv_redfish_bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
+/// use url::Url;
+///
+/// let client = Client::new()?;
+/// let endpoint = Url::parse("https://bmc.example")?;
+/// let credentials = BmcCredentials::username_password("admin".to_owned(), None);
+/// let bmc = HttpBmc::new(client, endpoint, credentials, CacheSettings::default());
+/// let _limited_bmc = bmc.with_request_concurrency_limit(NonZeroUsize::MIN);
+/// # Ok(())
+/// # }
+/// ```
+pub struct ConcurrencyLimitedBmc<B> {
+    inner: B,
+    semaphore: Semaphore,
+}
+
+impl<B> ConcurrencyLimitedBmc<B> {
+    pub(crate) const fn new(inner: B, limit: NonZeroUsize) -> Self {
+        Self {
+            inner,
+            semaphore: Semaphore::new(limit.get()),
+        }
+    }
+}
+
+impl<C: HttpClient> ConcurrencyLimitedBmc<HttpBmc<C>>
+where
+    C::Error: CacheableError,
+{
+    /// Replaces the credentials used by the wrapped [`HttpBmc`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the wrapped BMC's credentials lock is poisoned.
+    pub fn set_credentials(&self, credentials: BmcCredentials) {
+        self.inner.set_credentials(credentials);
+    }
+}
+
+impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
+    type Error = B::Error;
+
+    async fn expand<T: Expandable>(
+        &self,
+        id: &ODataId,
+        query: ExpandQuery,
+    ) -> Result<Arc<T>, Self::Error> {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.expand(id, query).await
+    }
+
+    async fn get<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
+        &self,
+        id: &ODataId,
+    ) -> Result<Arc<T>, Self::Error> {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.get(id).await
+    }
+
+    async fn filter<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
+        &self,
+        id: &ODataId,
+        query: FilterQuery,
+    ) -> Result<Arc<T>, Self::Error> {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.filter(id, query).await
+    }
+
+    async fn create<V, R>(
+        &self,
+        id: &ODataId,
+        query: &V,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        V: Send + Sync + Serialize,
+        R: Send + Sync + for<'de> Deserialize<'de>,
+    {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.create(id, query).await
+    }
+
+    async fn create_session<V, R>(
+        &self,
+        id: &ODataId,
+        query: &V,
+    ) -> Result<SessionCreateResponse<R>, Self::Error>
+    where
+        V: Send + Sync + Serialize,
+        R: Send + Sync + for<'de> Deserialize<'de>,
+    {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.create_session(id, query).await
+    }
+
+    async fn update<V, R>(
+        &self,
+        id: &ODataId,
+        etag: Option<&ODataETag>,
+        update: &V,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        V: Sync + Send + Serialize,
+        R: Send + Sync + Sized + for<'de> Deserialize<'de>,
+    {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.update(id, etag, update).await
+    }
+
+    async fn delete<R>(&self, id: &ODataId) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        R: EntityTypeRef + for<'de> Deserialize<'de>,
+    {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.delete(id).await
+    }
+
+    async fn action<T, R>(
+        &self,
+        action: &Action<T, R>,
+        params: &T,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        T: Send + Sync + Serialize,
+        R: Send + Sync + Sized + for<'de> Deserialize<'de>,
+    {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.action(action, params).await
+    }
+
+    async fn multipart_update<U, V, R>(
+        &self,
+        uri: &str,
+        request: MultipartUpdateRequest<'_, U, V>,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> Deserialize<'de>,
+        V: Send + Sync + Serialize,
+    {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.multipart_update(uri, request).await
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    async fn http_push_uri_update<U, R>(
+        &self,
+        uri: &str,
+        request: HttpPushUriUpdateRequest<U>,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> Deserialize<'de>,
+    {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.http_push_uri_update(uri, request).await
+    }
+
+    async fn stream<T>(&self, uri: &str) -> Result<BoxTryStream<T, Self::Error>, Self::Error>
+    where
+        T: Sized + for<'de> Deserialize<'de> + Send + 'static,
+    {
+        let _permit = self.semaphore.acquire().await;
+        self.inner.stream(uri).await
+    }
+}

--- a/bmc-http/src/concurrency.rs
+++ b/bmc-http/src/concurrency.rs
@@ -62,6 +62,23 @@ impl<B> ConcurrencyLimitedBmc<B> {
     }
 }
 
+impl<C: HttpClient> HttpBmc<C>
+where
+    C::Error: CacheableError,
+{
+    /// Configures the maximum number of concurrent Redfish operations.
+    ///
+    /// The limit covers complete logical operations, including transport
+    /// retries. Without this method, the BMC remains unlimited.
+    #[must_use]
+    pub const fn with_request_concurrency_limit(
+        self,
+        limit: NonZeroUsize,
+    ) -> ConcurrencyLimitedBmc<Self> {
+        ConcurrencyLimitedBmc::new(self, limit)
+    }
+}
+
 impl<C: HttpClient> ConcurrencyLimitedBmc<HttpBmc<C>>
 where
     C::Error: CacheableError,

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -38,19 +38,22 @@
 
 //! HTTP implementation of [`nv_redfish_core::Bmc`] trait.
 
-pub mod cache;
-pub mod credentials;
-
+mod concurrency;
 #[cfg(feature = "reqwest")]
 mod schema;
 
+pub mod cache;
+pub mod credentials;
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
+
+pub use concurrency::ConcurrencyLimitedBmc;
 
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -347,6 +350,18 @@ where
     #[allow(clippy::panic)] // See panics section.
     pub fn set_credentials(&self, credentials: BmcCredentials) {
         *self.credentials.write().expect("poisoned") = Arc::new(credentials);
+    }
+
+    /// Configures the maximum number of concurrent Redfish operations.
+    ///
+    /// The limit covers complete logical operations, including transport
+    /// retries. Without this method, the BMC remains unlimited.
+    #[must_use]
+    pub const fn with_request_concurrency_limit(
+        self,
+        limit: NonZeroUsize,
+    ) -> ConcurrencyLimitedBmc<Self> {
+        ConcurrencyLimitedBmc::new(self, limit)
     }
 }
 

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -38,22 +38,21 @@
 
 //! HTTP implementation of [`nv_redfish_core::Bmc`] trait.
 
+pub mod cache;
+pub mod credentials;
+
+#[cfg(feature = "http-extras")]
 mod concurrency;
 #[cfg(feature = "reqwest")]
 mod schema;
 
-pub mod cache;
-pub mod credentials;
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
-
-pub use concurrency::ConcurrencyLimitedBmc;
 
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::future::Future;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -75,6 +74,8 @@ use nv_redfish_core::UploadReader;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use url::Url;
 
+#[cfg(feature = "http-extras")]
+pub use concurrency::ConcurrencyLimitedBmc;
 #[doc(inline)]
 pub use credentials::BmcCredentials;
 
@@ -350,18 +351,6 @@ where
     #[allow(clippy::panic)] // See panics section.
     pub fn set_credentials(&self, credentials: BmcCredentials) {
         *self.credentials.write().expect("poisoned") = Arc::new(credentials);
-    }
-
-    /// Configures the maximum number of concurrent Redfish operations.
-    ///
-    /// The limit covers complete logical operations, including transport
-    /// retries. Without this method, the BMC remains unlimited.
-    #[must_use]
-    pub const fn with_request_concurrency_limit(
-        self,
-        limit: NonZeroUsize,
-    ) -> ConcurrencyLimitedBmc<Self> {
-        ConcurrencyLimitedBmc::new(self, limit)
     }
 }
 

--- a/bmc-http/tests/request_concurrency_tests.rs
+++ b/bmc-http/tests/request_concurrency_tests.rs
@@ -1,0 +1,660 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+#[cfg(feature = "reqwest")]
+mod tests {
+    use std::future::Future;
+    use std::num::NonZeroUsize;
+    use std::task::Poll;
+    use std::time::Duration;
+
+    use crate::common::test_utils::{create_test_credentials, TestResource};
+
+    use nv_redfish_bmc_http::reqwest::BmcError;
+    #[cfg(feature = "update-service-deprecated")]
+    use nv_redfish_bmc_http::HttpPushUriUpdateRequest;
+    use nv_redfish_bmc_http::{
+        BmcCredentials, CacheSettings, ConcurrencyLimitedBmc, HttpBmc, HttpClient,
+        MultipartUpdateRequest,
+    };
+    use nv_redfish_core::query::ExpandQuery;
+    #[cfg(feature = "update-service-deprecated")]
+    use nv_redfish_core::UploadStream;
+    use nv_redfish_core::{
+        Action, Bmc, BoxTryStream, DataStream, FilterQuery, ModificationResponse, ODataETag,
+        ODataId, SessionCreateResponse, UploadReader,
+    };
+
+    use futures_util::io::Cursor;
+    use http::HeaderMap;
+    use serde::{de::DeserializeOwned, Deserialize, Serialize};
+    use serde_json::Value as JsonValue;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio_test::{assert_pending, assert_ready_ok};
+    use url::Url;
+
+    const SSE_URI: &str = "/redfish/v1/EventService/SSE";
+
+    #[derive(Debug)]
+    enum TestResponse {
+        Resource,
+        Retry,
+        SseEstablished,
+    }
+
+    struct TransportAttempt {
+        path: String,
+        response: oneshot::Sender<TestResponse>,
+    }
+
+    #[derive(Clone)]
+    struct ControlledClient {
+        attempts: mpsc::UnboundedSender<TransportAttempt>,
+    }
+
+    impl ControlledClient {
+        async fn response_for(&self, path: String) -> Result<TestResponse, BmcError> {
+            let (response_tx, response_rx) = oneshot::channel();
+
+            self.attempts
+                .send(TransportAttempt {
+                    path,
+                    response: response_tx,
+                })
+                .map_err(|_| BmcError::InvalidRequest("test transport stopped".to_owned()))?;
+
+            response_rx
+                .await
+                .map_err(|_| BmcError::InvalidRequest("test response was dropped".to_owned()))
+        }
+
+        async fn modification_response<T>(
+            &self,
+            path: String,
+        ) -> Result<ModificationResponse<T>, BmcError> {
+            match self.response_for(path).await? {
+                TestResponse::Resource => Ok(ModificationResponse::Empty),
+                TestResponse::Retry | TestResponse::SseEstablished => Err(
+                    BmcError::InvalidRequest("unexpected test transport response".to_owned()),
+                ),
+            }
+        }
+    }
+
+    impl HttpClient for ControlledClient {
+        type Error = BmcError;
+
+        fn get<T>(
+            &self,
+            url: Url,
+            _credentials: &BmcCredentials,
+            _etag: Option<ODataETag>,
+            _custom_headers: &HeaderMap,
+        ) -> impl Future<Output = Result<T, Self::Error>> + Send
+        where
+            T: DeserializeOwned + Send + Sync,
+        {
+            let path = url.path().to_owned();
+
+            async move {
+                loop {
+                    match self.response_for(path.clone()).await? {
+                        TestResponse::Resource => {
+                            let value = serde_json::json!({
+                                "@odata.id": path,
+                                "@odata.etag": null,
+                                "name": "resource",
+                                "value": 1
+                            });
+
+                            return serde_json::from_value(value).map_err(BmcError::DecodeError);
+                        }
+                        TestResponse::Retry => {}
+                        TestResponse::SseEstablished => {
+                            return Err(BmcError::InvalidRequest(
+                                "unexpected SSE response for GET".to_owned(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        fn post<B, T>(
+            &self,
+            url: Url,
+            _body: &B,
+            _credentials: &BmcCredentials,
+            _custom_headers: &HeaderMap,
+        ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+        where
+            B: Serialize + Send + Sync,
+            T: DeserializeOwned + Send + Sync,
+        {
+            self.modification_response(url.path().to_owned())
+        }
+
+        fn post_session<B, T>(
+            &self,
+            url: Url,
+            _body: &B,
+            _custom_headers: &HeaderMap,
+        ) -> impl Future<Output = Result<SessionCreateResponse<T>, Self::Error>> + Send
+        where
+            B: Serialize + Send + Sync,
+            T: DeserializeOwned + Send + Sync,
+        {
+            let path = url.path().to_owned();
+
+            async move {
+                let _response = self.modification_response::<T>(path.clone()).await?;
+                let entity =
+                    serde_json::from_value(JsonValue::Null).map_err(BmcError::DecodeError)?;
+
+                Ok(SessionCreateResponse {
+                    entity,
+                    auth_token: "test-token".to_owned(),
+                    location: ODataId::from(path),
+                })
+            }
+        }
+
+        fn post_multipart_update<U, V, T>(
+            &self,
+            url: Url,
+            _request: MultipartUpdateRequest<'_, U, V>,
+            _credentials: &BmcCredentials,
+            _custom_headers: &HeaderMap,
+        ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+        where
+            U: UploadReader,
+            T: DeserializeOwned + Send + Sync,
+            V: Serialize + Send + Sync,
+        {
+            self.modification_response(url.path().to_owned())
+        }
+
+        #[cfg(feature = "update-service-deprecated")]
+        fn post_http_push_uri_update<U, T>(
+            &self,
+            url: Url,
+            _request: HttpPushUriUpdateRequest<U>,
+            _credentials: &BmcCredentials,
+            _custom_headers: &HeaderMap,
+        ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+        where
+            U: UploadReader,
+            T: DeserializeOwned + Send + Sync,
+        {
+            self.modification_response(url.path().to_owned())
+        }
+
+        fn patch<B, T>(
+            &self,
+            url: Url,
+            _etag: ODataETag,
+            _body: &B,
+            _credentials: &BmcCredentials,
+            _custom_headers: &HeaderMap,
+        ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+        where
+            B: Serialize + Send + Sync,
+            T: DeserializeOwned + Send + Sync,
+        {
+            self.modification_response(url.path().to_owned())
+        }
+
+        fn delete<T>(
+            &self,
+            url: Url,
+            _credentials: &BmcCredentials,
+            _custom_headers: &HeaderMap,
+        ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+        where
+            T: DeserializeOwned + Send + Sync,
+        {
+            self.modification_response(url.path().to_owned())
+        }
+
+        fn sse<T: Sized + for<'de> Deserialize<'de> + Send>(
+            &self,
+            url: Url,
+            _credentials: &BmcCredentials,
+            _custom_headers: &HeaderMap,
+        ) -> impl Future<Output = Result<BoxTryStream<T, Self::Error>, Self::Error>> + Send
+        {
+            let path = url.path().to_owned();
+
+            async move {
+                match self.response_for(path).await? {
+                    TestResponse::SseEstablished => {
+                        let stream = futures_util::stream::once(async {
+                            std::future::pending::<()>().await;
+                            Err::<T, BmcError>(BmcError::InvalidRequest(
+                                "unreachable test stream item".to_owned(),
+                            ))
+                        });
+
+                        let stream: BoxTryStream<T, BmcError> = Box::pin(stream);
+
+                        Ok(stream)
+                    }
+                    TestResponse::Resource | TestResponse::Retry => Err(BmcError::InvalidRequest(
+                        "unexpected non-SSE response for SSE".to_owned(),
+                    )),
+                }
+            }
+        }
+    }
+
+    struct TransportController {
+        attempts: mpsc::UnboundedReceiver<TransportAttempt>,
+    }
+
+    impl TransportController {
+        fn next_attempt(&mut self) -> TransportAttempt {
+            self.attempts
+                .try_recv()
+                .expect("a polled transport operation must report its attempt")
+        }
+
+        fn assert_no_attempt(&mut self) {
+            assert!(
+                matches!(
+                    self.attempts.try_recv(),
+                    Err(mpsc::error::TryRecvError::Empty)
+                ),
+                "an operation entered the transport while it should have been waiting"
+            );
+        }
+    }
+
+    fn controlled_client() -> (ControlledClient, TransportController) {
+        let (attempts_tx, attempts) = mpsc::unbounded_channel();
+
+        (
+            ControlledClient {
+                attempts: attempts_tx,
+            },
+            TransportController { attempts },
+        )
+    }
+
+    type LimitedTestBmc = ConcurrencyLimitedBmc<HttpBmc<ControlledClient>>;
+
+    fn create_bmc(client: ControlledClient, limit: NonZeroUsize) -> LimitedTestBmc {
+        let bmc = HttpBmc::new(
+            client,
+            Url::parse("http://bmc.example").expect("test endpoint must be valid"),
+            create_test_credentials(),
+            CacheSettings::with_capacity(0),
+        );
+
+        bmc.with_request_concurrency_limit(limit)
+    }
+
+    fn respond(attempt: TransportAttempt, response: TestResponse) {
+        attempt
+            .response
+            .send(response)
+            .expect("request future must accept its response");
+    }
+
+    #[derive(Clone, Copy)]
+    enum Operation {
+        Get,
+        Expand,
+        Filter,
+        Create,
+        CreateSession,
+        Update,
+        Delete,
+        Action,
+        MultipartUpdate,
+        #[cfg(feature = "update-service-deprecated")]
+        HttpPushUriUpdate,
+    }
+
+    impl Operation {
+        const fn path(self) -> &'static str {
+            match self {
+                Self::Get => "/get",
+                Self::Expand => "/expand",
+                Self::Filter => "/filter",
+                Self::Create => "/create",
+                Self::CreateSession => "/session",
+                Self::Update => "/update",
+                Self::Delete => "/delete",
+                Self::Action => "/action",
+                Self::MultipartUpdate => "/multipart-update",
+                #[cfg(feature = "update-service-deprecated")]
+                Self::HttpPushUriUpdate => "/http-push-uri-update",
+            }
+        }
+    }
+
+    async fn run_operation(bmc: &LimitedTestBmc, operation: Operation) -> Result<(), BmcError> {
+        let path = operation.path();
+        let id = ODataId::from(path.to_owned());
+
+        match operation {
+            Operation::Get => {
+                let _response = bmc.get::<TestResource>(&id).await?;
+            }
+            Operation::Expand => {
+                let _response = bmc
+                    .expand::<TestResource>(&id, ExpandQuery::current())
+                    .await?;
+            }
+            Operation::Filter => {
+                let _response = bmc
+                    .filter::<TestResource>(&id, FilterQuery::eq(&"value", 1))
+                    .await?;
+            }
+            Operation::Create => {
+                let _response = bmc
+                    .create::<JsonValue, JsonValue>(&id, &serde_json::json!({}))
+                    .await?;
+            }
+            Operation::CreateSession => {
+                bmc.create_session::<JsonValue, JsonValue>(&id, &serde_json::json!({}))
+                    .await?;
+            }
+            Operation::Update => {
+                let _response = bmc
+                    .update::<JsonValue, JsonValue>(&id, None, &serde_json::json!({}))
+                    .await?;
+            }
+            Operation::Delete => {
+                let _response = bmc.delete::<TestResource>(&id).await?;
+            }
+            Operation::Action => {
+                let action: Action<JsonValue, JsonValue> =
+                    serde_json::from_value(serde_json::json!({ "target": path }))
+                        .map_err(BmcError::DecodeError)?;
+
+                let _response = bmc.action(&action, &serde_json::json!({})).await?;
+            }
+            Operation::MultipartUpdate => {
+                let update_parameters = serde_json::json!({});
+
+                let request = MultipartUpdateRequest {
+                    update_parameters: &update_parameters,
+                    update_stream: DataStream::new("firmware.bin", Cursor::new(Vec::<u8>::new())),
+                    oem_parts: Vec::new(),
+                    upload_timeout: Duration::from_secs(60),
+                };
+
+                let _response = bmc
+                    .multipart_update::<_, _, JsonValue>(path, request)
+                    .await?;
+            }
+            #[cfg(feature = "update-service-deprecated")]
+            Operation::HttpPushUriUpdate => {
+                let request = HttpPushUriUpdateRequest {
+                    update_stream: UploadStream::new(Cursor::new(Vec::<u8>::new())),
+                    upload_timeout: Duration::from_secs(60),
+                };
+
+                let _response = bmc
+                    .http_push_uri_update::<_, JsonValue>(path, request)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn assert_operation_waits_for_permit(operation: Operation) {
+        let (client, mut transport) = controlled_client();
+        let bmc = create_bmc(client, NonZeroUsize::MIN);
+        let holder_id = ODataId::from("/holder".to_owned());
+
+        let mut holder = tokio_test::task::spawn(bmc.get::<TestResource>(&holder_id));
+        assert_pending!(holder.poll());
+        let holder_attempt = transport.next_attempt();
+
+        let mut operation_task = tokio_test::task::spawn(run_operation(&bmc, operation));
+        assert_pending!(operation_task.poll());
+        transport.assert_no_attempt();
+
+        respond(holder_attempt, TestResponse::Resource);
+        assert_ready_ok!(holder.poll());
+        assert!(operation_task.is_woken());
+        assert_pending!(operation_task.poll());
+        let operation_attempt = transport.next_attempt();
+
+        assert_eq!(operation_attempt.path, operation.path());
+        respond(operation_attempt, TestResponse::Resource);
+        assert_ready_ok!(operation_task.poll());
+    }
+
+    #[test]
+    fn limit_two_allows_two_operations_and_blocks_a_third() {
+        let (client, mut transport) = controlled_client();
+        let limit = NonZeroUsize::new(2).expect("test limit must be non-zero");
+        let bmc = create_bmc(client, limit);
+        let first_id = ODataId::from("/first".to_owned());
+        let second_id = ODataId::from("/second".to_owned());
+        let third_id = ODataId::from("/third".to_owned());
+
+        let mut first = tokio_test::task::spawn(bmc.get::<TestResource>(&first_id));
+        let mut second = tokio_test::task::spawn(bmc.get::<TestResource>(&second_id));
+        assert_pending!(first.poll());
+        assert_pending!(second.poll());
+        let first_attempt = transport.next_attempt();
+        let second_attempt = transport.next_attempt();
+
+        let mut third = tokio_test::task::spawn(bmc.get::<TestResource>(&third_id));
+        assert_pending!(third.poll());
+        transport.assert_no_attempt();
+
+        respond(first_attempt, TestResponse::Resource);
+        assert_ready_ok!(first.poll());
+
+        assert!(third.is_woken());
+        assert_pending!(third.poll());
+        let third_attempt = transport.next_attempt();
+
+        assert_eq!(third_attempt.path, "/third");
+        respond(second_attempt, TestResponse::Resource);
+        respond(third_attempt, TestResponse::Resource);
+        assert_ready_ok!(second.poll());
+        assert_ready_ok!(third.poll());
+    }
+
+    #[test]
+    fn shared_http_client_has_independent_per_bmc_limits() {
+        let (client, mut transport) = controlled_client();
+        let first_bmc = create_bmc(client.clone(), NonZeroUsize::MIN);
+        let second_bmc = create_bmc(client, NonZeroUsize::MIN);
+        let first_id = ODataId::from("/first".to_owned());
+        let second_id = ODataId::from("/second".to_owned());
+
+        let mut first = tokio_test::task::spawn(first_bmc.get::<TestResource>(&first_id));
+        assert_pending!(first.poll());
+        let first_attempt = transport.next_attempt();
+
+        let mut second = tokio_test::task::spawn(second_bmc.get::<TestResource>(&second_id));
+        assert_pending!(second.poll());
+        let second_attempt = transport.next_attempt();
+
+        assert_eq!(second_attempt.path, "/second");
+        respond(first_attempt, TestResponse::Resource);
+        respond(second_attempt, TestResponse::Resource);
+        assert_ready_ok!(first.poll());
+        assert_ready_ok!(second.poll());
+    }
+
+    #[test]
+    fn all_request_paths_wait_for_a_permit_at_limit_one() {
+        for operation in [
+            Operation::Get,
+            Operation::Expand,
+            Operation::Filter,
+            Operation::Create,
+            Operation::CreateSession,
+            Operation::Update,
+            Operation::Delete,
+            Operation::Action,
+            Operation::MultipartUpdate,
+        ] {
+            assert_operation_waits_for_permit(operation);
+        }
+
+        #[cfg(feature = "update-service-deprecated")]
+        assert_operation_waits_for_permit(Operation::HttpPushUriUpdate);
+    }
+
+    #[test]
+    fn retry_holds_permit_for_entire_logical_operation() {
+        let (client, mut transport) = controlled_client();
+        let bmc = create_bmc(client, NonZeroUsize::MIN);
+        let retry_id = ODataId::from("/retry".to_owned());
+        let other_id = ODataId::from("/other".to_owned());
+
+        let mut retrying = tokio_test::task::spawn(bmc.get::<TestResource>(&retry_id));
+        assert_pending!(retrying.poll());
+        let first_attempt = transport.next_attempt();
+
+        let mut other = tokio_test::task::spawn(bmc.get::<TestResource>(&other_id));
+        assert_pending!(other.poll());
+        transport.assert_no_attempt();
+
+        respond(first_attempt, TestResponse::Retry);
+        assert_pending!(retrying.poll());
+        let second_attempt = transport.next_attempt();
+
+        assert_eq!(second_attempt.path, "/retry");
+        transport.assert_no_attempt();
+
+        respond(second_attempt, TestResponse::Resource);
+        assert_ready_ok!(retrying.poll());
+
+        assert!(other.is_woken());
+        assert_pending!(other.poll());
+        let other_attempt = transport.next_attempt();
+
+        assert_eq!(other_attempt.path, "/other");
+        respond(other_attempt, TestResponse::Resource);
+        assert_ready_ok!(other.poll());
+    }
+
+    #[test]
+    fn canceling_waiter_does_not_consume_capacity() {
+        let (client, mut transport) = controlled_client();
+        let bmc = create_bmc(client, NonZeroUsize::MIN);
+        let first_id = ODataId::from("/first".to_owned());
+        let canceled_id = ODataId::from("/canceled".to_owned());
+        let next_id = ODataId::from("/next".to_owned());
+
+        let mut first = tokio_test::task::spawn(bmc.get::<TestResource>(&first_id));
+        assert_pending!(first.poll());
+        let first_attempt = transport.next_attempt();
+
+        let mut canceled = tokio_test::task::spawn(bmc.get::<TestResource>(&canceled_id));
+        assert_pending!(canceled.poll());
+        transport.assert_no_attempt();
+        drop(canceled);
+
+        let mut next = tokio_test::task::spawn(bmc.get::<TestResource>(&next_id));
+        assert_pending!(next.poll());
+        transport.assert_no_attempt();
+        respond(first_attempt, TestResponse::Resource);
+        assert_ready_ok!(first.poll());
+
+        assert!(next.is_woken());
+        assert_pending!(next.poll());
+        let next_attempt = transport.next_attempt();
+
+        assert_eq!(next_attempt.path, "/next");
+        respond(next_attempt, TestResponse::Resource);
+        assert_ready_ok!(next.poll());
+    }
+
+    #[test]
+    fn canceling_in_flight_operation_releases_capacity() {
+        let (client, mut transport) = controlled_client();
+        let bmc = create_bmc(client, NonZeroUsize::MIN);
+        let first_id = ODataId::from("/first".to_owned());
+        let next_id = ODataId::from("/next".to_owned());
+
+        let mut first = tokio_test::task::spawn(bmc.get::<TestResource>(&first_id));
+        assert_pending!(first.poll());
+        let first_attempt = transport.next_attempt();
+
+        let mut next = tokio_test::task::spawn(bmc.get::<TestResource>(&next_id));
+        assert_pending!(next.poll());
+        transport.assert_no_attempt();
+
+        drop(first);
+        drop(first_attempt);
+
+        assert!(next.is_woken());
+        assert_pending!(next.poll());
+        let next_attempt = transport.next_attempt();
+
+        assert_eq!(next_attempt.path, "/next");
+        respond(next_attempt, TestResponse::Resource);
+        assert_ready_ok!(next.poll());
+    }
+
+    #[test]
+    fn sse_holds_permit_during_establishment_and_releases_it_afterward() {
+        let (client, mut transport) = controlled_client();
+        let bmc = create_bmc(client, NonZeroUsize::MIN);
+        let next_id = ODataId::from("/next".to_owned());
+
+        let mut sse = tokio_test::task::spawn(bmc.stream::<JsonValue>(SSE_URI));
+
+        assert!(matches!(sse.poll(), Poll::Pending));
+        let sse_attempt = transport.next_attempt();
+
+        assert_eq!(sse_attempt.path, SSE_URI);
+
+        let mut next = tokio_test::task::spawn(bmc.get::<TestResource>(&next_id));
+        assert_pending!(next.poll());
+        transport.assert_no_attempt();
+
+        respond(sse_attempt, TestResponse::SseEstablished);
+
+        let _stream = assert_ready_ok!(sse.poll());
+
+        assert!(next.is_woken());
+        assert_pending!(next.poll());
+        let next_attempt = transport.next_attempt();
+
+        assert_eq!(next_attempt.path, "/next");
+        respond(next_attempt, TestResponse::Resource);
+        assert_ready_ok!(next.poll());
+    }
+
+    #[test]
+    fn omitted_limit_preserves_unlimited_transport_entry() {
+        let (client, mut transport) = controlled_client();
+
+        let bmc = HttpBmc::new(
+            client,
+            Url::parse("http://bmc.example").expect("test endpoint must be valid"),
+            create_test_credentials(),
+            CacheSettings::with_capacity(0),
+        );
+
+        let first_id = ODataId::from("/first".to_owned());
+        let second_id = ODataId::from("/second".to_owned());
+
+        let mut first = tokio_test::task::spawn(bmc.get::<TestResource>(&first_id));
+        let mut second = tokio_test::task::spawn(bmc.get::<TestResource>(&second_id));
+        assert_pending!(first.poll());
+        assert_pending!(second.poll());
+        let first_attempt = transport.next_attempt();
+        let second_attempt = transport.next_attempt();
+
+        respond(first_attempt, TestResponse::Resource);
+        respond(second_attempt, TestResponse::Resource);
+        assert_ready_ok!(first.poll());
+        assert_ready_ok!(second.poll());
+    }
+}

--- a/bmc-http/tests/request_concurrency_tests.rs
+++ b/bmc-http/tests/request_concurrency_tests.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-#[cfg(feature = "reqwest")]
+#[cfg(all(feature = "reqwest", feature = "http-extras"))]
 mod tests {
     use std::future::Future;
     use std::num::NonZeroUsize;

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -17,6 +17,7 @@ mod common;
 
 #[cfg(feature = "reqwest")]
 mod reqwest_client_tests {
+    #[cfg(feature = "http-extras")]
     use std::num::NonZeroUsize;
     use std::time::Duration;
 
@@ -25,6 +26,7 @@ mod reqwest_client_tests {
     use nv_redfish_bmc_http::reqwest::Client;
     use nv_redfish_bmc_http::reqwest::ClientParams;
     use nv_redfish_bmc_http::reqwest::RetryPolicy;
+    #[cfg(any(feature = "http-extras", feature = "update-service-deprecated"))]
     use nv_redfish_bmc_http::BmcCredentials;
     use nv_redfish_bmc_http::CacheSettings;
     use nv_redfish_bmc_http::HttpBmc;
@@ -135,6 +137,7 @@ mod reqwest_client_tests {
         Ok(())
     }
 
+    #[cfg(feature = "http-extras")]
     #[tokio::test]
     async fn concurrency_limited_bmc_preserves_credential_rotation() {
         let mock_server = MockServer::start().await;

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -17,6 +17,7 @@ mod common;
 
 #[cfg(feature = "reqwest")]
 mod reqwest_client_tests {
+    use std::num::NonZeroUsize;
     use std::time::Duration;
 
     use futures_util::io::Cursor;
@@ -135,7 +136,7 @@ mod reqwest_client_tests {
     }
 
     #[tokio::test]
-    async fn test_set_credentials() {
+    async fn concurrency_limited_bmc_preserves_credential_rotation() {
         let mock_server = MockServer::start().await;
         let first_resource_path = paths::SYSTEMS_1;
         let second_resource_path = paths::MANAGERS_1;
@@ -161,7 +162,7 @@ mod reqwest_client_tests {
             .mount(&mock_server)
             .await;
 
-        let bmc = create_test_bmc(&mock_server);
+        let bmc = create_test_bmc(&mock_server).with_request_concurrency_limit(NonZeroUsize::MIN);
 
         let first_id = create_odata_id(first_resource_path);
         let first = bmc.get::<TestResource>(&first_id).await.unwrap();

--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -23,6 +23,10 @@ all-features = true
 default = []
 
 bmc-http = [ "dep:nv-redfish-bmc-http" ]
+http-extras = [
+    "bmc-http",
+    "nv-redfish-bmc-http/http-extras",
+]
 
 std-redfish = [
     "accounts",


### PR DESCRIPTION
### Why

Multiple callers can share one `HttpBmc` and issue overlapping operations against a resource-constrained BMC.

Most additions are test code. Added `async-lock` dependency after comparing to alternative methods.

### Changes

- Added an opt-in concurrency wrapper for `HttpBmc`, behind `http-extras` feature gate.
- Enforced independent limits for each wrapper, including with shared HTTP clients.
- Held permits across complete operations and retries.
- Covered all Redfish operations, including SSE connection establishment.
- Released SSE permits after establishment; active streams are not limited.
- Used a runtime-neutral, cancellation-safe asynchronous semaphore.

### Compatibility

- Existing constructors and unwrapped `HttpBmc` behavior are unchanged.
- Concurrency remains unlimited unless explicitly configured.
- Enabling the limit returns `ConcurrencyLimitedBmc<HttpBmc<C>>` (`http-extras` feature is required).