### PR TITLE
fix(quirks): apply SSE event quirks to Wiwynn BMCs

### DIFF
--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -36,6 +36,7 @@ enum Platform {
     VeraRubin,
     Nvidia,
     NvidiaDpu,
+    Wiwynn,
     Anonymous1_9_0,
     NvSwitch,
 }
@@ -68,6 +69,9 @@ impl BmcQuirks {
             Some("Nvidia") if matches!(product_str, Some("Nvidia-BMCMezz" | "BlueField-3 DPU")) => {
                 Some(Platform::NvidiaDpu)
             }
+            // Wiwynn ODM GB200 NVL trays report their own vendor rather than
+            // `NVIDIA`
+            Some("WIWYNN") => Some(Platform::Wiwynn),
             None if redfish_version_str == Some("1.9.0") => Some(Platform::Anonymous1_9_0),
             _ => None,
         };
@@ -182,8 +186,8 @@ impl BmcQuirks {
     /// In some implementations, Event records in SSE payload do not include
     /// `MemberId`.
     #[cfg(feature = "event-service")]
-    pub(crate) fn event_service_sse_no_member_id(&self) -> bool {
-        self.platform == Some(Platform::Nvidia)
+    pub(crate) const fn event_service_sse_no_member_id(&self) -> bool {
+        matches!(self.platform, Some(Platform::Nvidia | Platform::Wiwynn))
     }
 
     /// In some implementations, Event records in SSE payload use compact
@@ -195,8 +199,8 @@ impl BmcQuirks {
 
     /// In some implementations, Event records in SSE payload omit `EventType`.
     #[cfg(feature = "event-service")]
-    pub(crate) fn event_service_sse_missing_event_type(&self) -> bool {
-        self.platform == Some(Platform::Nvidia)
+    pub(crate) const fn event_service_sse_missing_event_type(&self) -> bool {
+        matches!(self.platform, Some(Platform::Nvidia | Platform::Wiwynn))
     }
 
     /// SSE payload does not include `@odata.id`.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -28,6 +28,7 @@ nv-redfish = { workspace = true, features = [
     "chassis",
     "controls",
     "computer-systems",
+    "event-service",
     "managers",
     "manager-network-protocol",
     "memory",

--- a/tests/tests/test-event-service-sse-wiwynn.rs
+++ b/tests/tests/test-event-service-sse-wiwynn.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Integration tests for SSE event records that omit `MemberId` and `EventType`.
+//!
+//! Both carry `Redfish.Required`, so a record missing either fails to
+//! deserialize. `BmcQuirks` selects patches that supply them, but only for a
+//! vendor it classifies.
+
+use futures_util::StreamExt as _;
+use nv_redfish::event_service::EventStreamPayload;
+use nv_redfish::ServiceRoot;
+use nv_redfish_core::ODataId;
+use nv_redfish_tests::Bmc;
+use nv_redfish_tests::Expect;
+use nv_redfish_tests::ODATA_ID;
+use nv_redfish_tests::ODATA_TYPE;
+use serde_json::json;
+use serde_json::Value;
+use std::error::Error as StdError;
+use std::sync::Arc;
+use tokio::test;
+
+const SERVICE_ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_13_0.ServiceRoot";
+const EVENT_SERVICE_DATA_TYPE: &str = "#EventService.v1_9_3.EventService";
+const EVENT_DATA_TYPE: &str = "#Event.v1_9_2.Event";
+const EVENT_SERVICE_ID: &str = "/redfish/v1/EventService";
+const SSE_URI: &str = "/redfish/v1/EventService/SSE";
+const EVENT_ID: &str = "337";
+
+/// Wiwynn ODM GB200 NVL trays omit both properties from every SSE event record.
+#[test]
+async fn wiwynn_sse_record_missing_member_id_and_event_type_is_supported(
+) -> Result<(), Box<dyn StdError>> {
+    let payload = first_stream_payload("WIWYNN").await?;
+
+    assert!(
+        matches!(payload, Ok(EventStreamPayload::Event(_))),
+        "Wiwynn event record must deserialize, got {:?}",
+        payload
+    );
+
+    Ok(())
+}
+
+/// The control: asserting a record deserializes proves nothing unless the same
+/// record is known to fail when no quirk is selected.
+#[test]
+async fn unclassified_vendor_drops_the_same_record() -> Result<(), Box<dyn StdError>> {
+    let payload = first_stream_payload("ACME").await?;
+
+    // Serde reports whichever required property it reaches first, so assert on
+    // the rejection rather than on which one.
+    let error = payload.expect_err("record must fail when the vendor selects no patches");
+    let error = format!("{error:?}");
+    assert!(
+        error.contains("missing field"),
+        "must fail on a missing required property, not something incidental: {}",
+        error
+    );
+
+    Ok(())
+}
+
+/// Regression guard for the NVIDIA-branded trays the patches were added for.
+#[test]
+async fn nvidia_sse_record_missing_member_id_and_event_type_is_supported(
+) -> Result<(), Box<dyn StdError>> {
+    let payload = first_stream_payload("NVIDIA").await?;
+
+    assert!(
+        matches!(payload, Ok(EventStreamPayload::Event(_))),
+        "NVIDIA event record must deserialize, got {:?}",
+        payload
+    );
+
+    Ok(())
+}
+
+/// Returns the stream's first item still wrapped: the error case is a result
+/// these tests assert on, not a failure.
+async fn first_stream_payload(
+    vendor: &str,
+) -> Result<Result<EventStreamPayload, impl std::fmt::Debug>, Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let root_id = ODataId::service_root();
+
+    bmc.expect(Expect::get(&root_id, service_root(&root_id, vendor)));
+    let service_root = ServiceRoot::new(bmc.clone()).await?;
+
+    bmc.expect(Expect::get(EVENT_SERVICE_ID, event_service()));
+    let event_service = service_root
+        .event_service()
+        .await?
+        .expect("service root advertises an EventService");
+
+    bmc.expect(Expect::stream(SSE_URI, json!([event_payload()])));
+    let mut events = event_service.events().await?;
+
+    Ok(events.next().await.expect("stream yields one payload"))
+}
+
+fn service_root(root_id: &ODataId, vendor: &str) -> Value {
+    json!({
+        ODATA_ID: root_id,
+        ODATA_TYPE: SERVICE_ROOT_DATA_TYPE,
+        "Id": "RootService",
+        "Name": "RootService",
+        "Vendor": vendor,
+        "EventService": { ODATA_ID: EVENT_SERVICE_ID },
+        "Links": {
+            "Sessions": { ODATA_ID: format!("{root_id}/SessionService/Sessions") }
+        },
+    })
+}
+
+fn event_service() -> Value {
+    json!({
+        ODATA_ID: EVENT_SERVICE_ID,
+        ODATA_TYPE: EVENT_SERVICE_DATA_TYPE,
+        "Id": "EventService",
+        "Name": "Event Service",
+        "ServerSentEventUri": SSE_URI,
+    })
+}
+
+/// A platform-error record as the GB200 NVL trays emit it — note the absent
+/// `MemberId` and `EventType`.
+fn event_payload() -> Value {
+    json!({
+        ODATA_ID: format!("{SSE_URI}#/Event1"),
+        ODATA_TYPE: EVENT_DATA_TYPE,
+        "Id": EVENT_ID,
+        "Name": "Event Log",
+        "Events": [
+            {
+                "EventId": EVENT_ID,
+                "EventTimestamp": "2026-07-31T14:21:01+00:00",
+                "MessageId": "Platform.1.0.PlatformError",
+                "MessageSeverity": "Critical",
+            }
+        ],
+    })
+}


### PR DESCRIPTION
Wiwynn ODM GB200 NVL trays report `"Vendor": "WIWYNN"` in their Redfish root. These BMCs have the same quirks as the GB200 trays. with vendor=Nvidia.

Their SSE event records omit both MemberId and EventType, both of which are formally required by Event.v1_10_1. Deserialization fails and takes down the whole SSE connection rather than the single record, so a deployment configured for SSE ingestion cannot ingest any Redfish event from this hardware at all.

Add a Platform::Wiwynn variant and enable event_service_sse_no_member_id and event_service_sse_missing_event_type for it. These are currently the only two quirks gated on Platform::Nvidia, so classifying Wiwynn as Nvidia would be equivalent in effect today, but a distinct variant keeps future NVIDIA-specific quirks from applying to hardware they have not been validated against.

Observed on BMC_0 firmware 25.06-2_NV_WW_02 / HGX_BMC_0 GB200Nvl-25.06-A.