### PR TITLE
feat: support deprecated fields

### DIFF
--- a/csdl-compiler/examples/schema-compilation.rs
+++ b/csdl-compiler/examples/schema-compilation.rs
@@ -113,12 +113,10 @@ fn main() -> Result<(), Error> {
                         ptype: NavPropertyType::Collection(t),
                         ..
                     }) => println!("      {}: {}[]", name, t),
-                    NavProperty::Reference(OneOrCollection::One(name)) => {
-                        println!("      {}: ref", name);
-                    }
-                    NavProperty::Reference(OneOrCollection::Collection(name)) => {
-                        println!("      {}: ref[]", name);
-                    }
+                    NavProperty::Reference { cardinality, .. } => match cardinality {
+                        OneOrCollection::One(name) => println!("      {}: ref", name),
+                        OneOrCollection::Collection(name) => println!("      {}: ref[]", name),
+                    },
                 }
             }
         }
@@ -154,12 +152,10 @@ fn main() -> Result<(), Error> {
                         ptype: NavPropertyType::Collection(t),
                         ..
                     }) => println!("      {}: {}[]", name, t),
-                    NavProperty::Reference(OneOrCollection::One(name)) => {
-                        println!("      {}: ref", name);
-                    }
-                    NavProperty::Reference(OneOrCollection::Collection(name)) => {
-                        println!("      {}: ref[]", name);
-                    }
+                    NavProperty::Reference { cardinality, .. } => match cardinality {
+                        OneOrCollection::One(name) => println!("      {}: ref", name),
+                        OneOrCollection::Collection(name) => println!("      {}: ref[]", name),
+                    },
                 }
             }
         }

--- a/csdl-compiler/src/compiler/entity_type.rs
+++ b/csdl-compiler/src/compiler/entity_type.rs
@@ -131,7 +131,7 @@ impl<'a> EntityType<'a> {
                 .find(|p| p.name().inner().inner() == "Members")
                 .and_then(|p| match p {
                     NavProperty::Expandable(v) => Some(v),
-                    NavProperty::Reference(_) => None,
+                    NavProperty::Reference { .. } => None,
                 })
                 .map(|p| p.ptype.name())
         } else {

--- a/csdl-compiler/src/compiler/mod.rs
+++ b/csdl-compiler/src/compiler/mod.rs
@@ -554,7 +554,11 @@ mod test {
                    <Property Name="RedfishVersion" Type="Edm.String" Nullable="false">
                      <Annotation Term="OData.Description" String="The version of the Redfish service."/>
                    </Property>
+                   <NavigationProperty Name="LegacyTarget" Type="ServiceRoot.Target">
+                     <Annotation Term="Redfish.Deprecated" String="Use TargetV2."/>
+                   </NavigationProperty>
                  </EntityType>
+                 <EntityType Name="Target"/>
                </Schema>
                <Schema Namespace="Schema.v1_0_0">
                  <EntityContainer Name="ServiceContainer">
@@ -576,7 +580,10 @@ mod test {
             .compile(
                 &["Service".parse().unwrap()],
                 &EntityTypeFilter::new_restrictive(vec![]),
-                Config::default(),
+                Config {
+                    entity_type_filter: EntityTypeFilter::new_restrictive(vec![]),
+                    ..Config::default()
+                },
             )
             .unwrap();
         let qtypename: QualifiedTypeName = "ServiceRoot.ServiceRoot".parse().unwrap();
@@ -598,5 +605,11 @@ mod test {
                 .inner(),
             &"The version of the Redfish service."
         );
+        assert!(matches!(
+            &et.properties.nav_properties[0],
+            NavProperty::Reference { redfish, .. }
+                if redfish.deprecation.is_some_and(|deprecation|
+                    deprecation.description == Some("Use TargetV2."))
+        ));
     }
 }

--- a/csdl-compiler/src/compiler/properties.rs
+++ b/csdl-compiler/src/compiler/properties.rs
@@ -157,8 +157,11 @@ impl<'a> Properties<'a> {
             if redfish.excerpt_copy.is_none() {
                 // Don't add excerpt copy of entities that are not
                 // included in entity pattern.
-                p.nav_properties
-                    .push(NavProperty::Reference(v.ptype.as_ref().map(|_| &v.name)));
+                p.nav_properties.push(NavProperty::Reference {
+                    cardinality: v.ptype.as_ref().map(|_| &v.name),
+                    odata: OData::new(MustHaveId::new(false), v),
+                    redfish,
+                });
             }
             Ok(Compiled::default())
         }
@@ -284,7 +287,7 @@ pub struct Property<'a> {
     /// Attached `OData` annotations.
     pub odata: OData<'a>,
     /// Redfish-specific property annotations.
-    pub redfish: RedfishProperty,
+    pub redfish: RedfishProperty<'a>,
     /// Whether the property is nullable.
     pub nullable: IsNullable,
     /// Redfish specification is not very specific about which
@@ -322,7 +325,14 @@ pub enum NavProperty<'a> {
     /// Expandable navigation property (with known type).
     Expandable(NavPropertyExpandable<'a>),
     /// Reference navigation property (type is left as reference).
-    Reference(OneOrCollection<&'a PropertyName>),
+    Reference {
+        /// Property cardinality and identifier.
+        cardinality: OneOrCollection<&'a PropertyName>,
+        /// Attached `OData` annotations.
+        odata: OData<'a>,
+        /// Redfish-specific property annotations.
+        redfish: RedfishProperty<'a>,
+    },
 }
 
 impl<'a> NavProperty<'a> {
@@ -331,7 +341,7 @@ impl<'a> NavProperty<'a> {
     pub const fn name(&'a self) -> &'a PropertyName {
         match self {
             Self::Expandable(v) => v.name,
-            Self::Reference(n) => n.inner(),
+            Self::Reference { cardinality, .. } => cardinality.inner(),
         }
     }
 }
@@ -346,7 +356,7 @@ pub struct NavPropertyExpandable<'a> {
     /// Attached `OData` annotations.
     pub odata: OData<'a>,
     /// Redfish-specific property annotations.
-    pub redfish: RedfishProperty,
+    pub redfish: RedfishProperty<'a>,
     /// Whether the property is nullable.
     pub nullable: IsNullable,
 }

--- a/csdl-compiler/src/compiler/redfish.rs
+++ b/csdl-compiler/src/compiler/redfish.rs
@@ -16,6 +16,7 @@
 //! Redfish-specific attributes used during code generation.
 
 use crate::redfish::annotations::RedfishAnnotations;
+use crate::redfish::Deprecation;
 use crate::redfish::DynamicProperties;
 use crate::redfish::Excerpt;
 use crate::redfish::ExcerptCopy;
@@ -25,7 +26,7 @@ use crate::IsRequiredOnCreate;
 
 /// Redfish property attributes attached to compiled entities.
 #[derive(Debug)]
-pub struct RedfishProperty {
+pub struct RedfishProperty<'a> {
     /// Whether the property is required.
     pub is_required: IsRequired,
     /// Whether the property is required on create.
@@ -36,18 +37,21 @@ pub struct RedfishProperty {
     pub excerpt: Option<Excerpt>,
     /// Property is excerpt copy of the resource.
     pub excerpt_copy: Option<ExcerptCopy>,
+    /// Redfish deprecation metadata.
+    pub deprecation: Option<Deprecation<'a>>,
 }
 
-impl RedfishProperty {
+impl<'a> RedfishProperty<'a> {
     /// Create a new instance from an object that provides Redfish
     /// property annotations.
-    pub fn new(src: &impl RedfishAnnotations) -> Self {
+    pub fn new(src: &'a impl RedfishAnnotations) -> Self {
         Self {
             is_required: src.is_required(),
             is_required_on_create: src.is_required_on_create(),
             is_excerpt_only: src.is_excerpt_only(),
             excerpt: src.excerpt(),
             excerpt_copy: src.excerpt_copy(),
+            deprecation: src.deprecation(),
         }
     }
 }

--- a/csdl-compiler/src/edmx/annotation.rs
+++ b/csdl-compiler/src/edmx/annotation.rs
@@ -19,7 +19,6 @@ use crate::edmx::attribute_values::Error as AttributeValuesError;
 use crate::edmx::EnumMemberName;
 use crate::edmx::QualifiedTypeName;
 use serde::de::Error as DeError;
-use serde::de::Visitor;
 use serde::Deserialize;
 use serde::Deserializer;
 use std::fmt::Display;
@@ -39,12 +38,20 @@ pub struct Annotation {
     pub bool_value: Option<bool>,
     #[serde(rename = "@Int")]
     pub int_value: Option<i64>,
-    #[serde(rename = "@EnumMember")]
-    pub enum_member: Option<Box<AnnotationEnumMember>>,
+    /// 14.4.7 `EnumMember` expression in attribute or child-element form.
+    #[serde(rename = "@EnumMember", alias = "EnumMember")]
+    enum_member: Option<EnumMemberExpression>,
     #[serde(rename = "Collection")]
     pub collection: Option<AnnotationCollection>,
     #[serde(rename = "Record")]
     pub record: Option<AnnotationRecord>,
+}
+
+impl Annotation {
+    /// Members from the `EnumMember` expression.
+    pub fn enum_members(&self) -> impl Iterator<Item = &AnnotationEnumMember> + '_ {
+        self.enum_member.iter().flat_map(|expression| &expression.0)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -82,12 +89,23 @@ pub struct PropertyValue {
     pub string_value: Option<String>,
     #[serde(rename = "@Int")]
     pub int_value: Option<i64>,
+    /// 14.4.7 `EnumMember` expression in attribute or child-element form.
+    #[serde(rename = "@EnumMember", alias = "EnumMember")]
+    enum_member: Option<EnumMemberExpression>,
+}
+
+impl PropertyValue {
+    /// Members from `EnumMember` expressions in either supported XML form.
+    pub fn enum_members(&self) -> impl Iterator<Item = &AnnotationEnumMember> + '_ {
+        self.enum_member.iter().flat_map(|expression| &expression.0)
+    }
 }
 
 #[derive(Debug)]
 pub enum Error {
     NoForwardSlash,
     NoEnumMemberName,
+    TrailingSegments,
     BadTypeName(AttributeValuesError),
     BadMemberName(AttributeValuesError),
     InvalidEnumMember(String, Box<Self>),
@@ -98,6 +116,7 @@ impl Display for Error {
         match self {
             Self::NoForwardSlash => "no forward slash (/) in string".fmt(f),
             Self::NoEnumMemberName => "no enum member in string".fmt(f),
+            Self::TrailingSegments => "extra segments after enum member name".fmt(f),
             Self::BadTypeName(e) => write!(f, "bad enum type name: {e}"),
             Self::BadMemberName(e) => write!(f, "bad enum member name: {e}"),
             Self::InvalidEnumMember(s, e) => write!(f, "invalid enum memeber: {s}: {e}"),
@@ -105,11 +124,7 @@ impl Display for Error {
     }
 }
 
-/// 14.4.7 Expression edm:EnumMember
-///
-/// Note that spec gives possiblitity of more than one space-separated
-/// member for `IsFlags` enum. But it is not used so we keep support
-/// only one member here.
+/// One member of a 14.4.7 `edm:EnumMember` expression.
 #[derive(Debug)]
 pub struct AnnotationEnumMember {
     pub tname: QualifiedTypeName,
@@ -130,24 +145,59 @@ impl FromStr for AnnotationEnumMember {
             .ok_or(Error::NoEnumMemberName)
             .and_then(|mname_str| mname_str.parse().map_err(Error::BadMemberName))
             .map_err(|e| Error::InvalidEnumMember(s.into(), Box::new(e)))?;
+        if iter.next().is_some() {
+            return Err(Error::InvalidEnumMember(
+                s.into(),
+                Box::new(Error::TrailingSegments),
+            ));
+        }
         Ok(Self { tname, mname })
     }
 }
 
-impl<'de> Deserialize<'de> for AnnotationEnumMember {
+/// A 14.4.7 `edm:EnumMember` expression.
+#[derive(Debug)]
+struct EnumMemberExpression(Vec<AnnotationEnumMember>);
+
+impl<'de> Deserialize<'de> for EnumMemberExpression {
     fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        struct EmVisitor {}
-        impl Visitor<'_> for EmVisitor {
-            type Value = AnnotationEnumMember;
-
-            fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
-                formatter.write_str("Annotation enum member string")
-            }
-            fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
-                value.parse().map_err(DeError::custom)
-            }
+        let value = String::deserialize(de)?;
+        let members = value
+            .split_whitespace()
+            .map(str::parse)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(DeError::custom)?;
+        if members.is_empty() {
+            Err(DeError::custom("empty enum member expression"))
+        } else {
+            Ok(Self(members))
         }
+    }
+}
 
-        de.deserialize_string(EmVisitor {})
+#[cfg(test)]
+mod tests {
+    use super::Annotation;
+    use quick_xml::de::from_str;
+
+    #[test]
+    fn enum_member_expressions_support_elements_and_flags() {
+        let annotation: Annotation = from_str(
+            r#"<Annotation Term="Example.Term">
+                 <EnumMember>Example.Flags/One Example.Flags/Two</EnumMember>
+               </Annotation>"#,
+        )
+        .expect("valid annotation");
+        let members = annotation
+            .enum_members()
+            .map(|member| member.mname.inner().inner().as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(members, ["One", "Two"]);
+
+        assert!(from_str::<Annotation>(
+            r#"<Annotation Term="Example.Term" EnumMember="Example.Flags/One/Trailing"/>"#
+        )
+        .is_err());
     }
 }

--- a/csdl-compiler/src/generator/rust/doc.rs
+++ b/csdl-compiler/src/generator/rust/doc.rs
@@ -16,6 +16,7 @@
 //! Generation of Rust doc by comment lines.
 
 use crate::compiler::OData;
+use crate::redfish::Deprecation;
 use proc_macro2::Delimiter;
 use proc_macro2::Group;
 use proc_macro2::Ident;
@@ -27,12 +28,29 @@ use proc_macro2::TokenStream;
 use proc_macro2::TokenTree;
 use std::fmt::Display;
 
-/// Generate rust doc from description and long description.
+/// Generate Rust documentation from `OData` descriptions.
 #[must_use]
 pub fn format_and_generate(name: impl Display, odata: &OData<'_>) -> TokenStream {
     format(name, odata)
         .map(|lines| generate(&lines))
         .unwrap_or_default()
+}
+
+/// Generate Rust documentation with Redfish deprecation metadata.
+#[must_use]
+pub fn format_and_generate_with_deprecation(
+    name: impl Display,
+    odata: &OData<'_>,
+    deprecation: Option<Deprecation<'_>>,
+) -> TokenStream {
+    let mut lines = format(name, odata).unwrap_or_default();
+    if let Some(deprecation) = deprecation {
+        if !lines.is_empty() {
+            lines.push(String::new());
+        }
+        lines.extend(split_by_lines(&deprecation_text(deprecation)));
+    }
+    generate(&lines)
 }
 
 /// Format long and short descriptions to multiple lines.
@@ -55,6 +73,17 @@ pub fn format(name: impl Display, odata: &OData<'_>) -> Option<Vec<String>> {
             Some(result)
         }
     }
+}
+
+fn deprecation_text(deprecation: Deprecation<'_>) -> String {
+    let heading = deprecation.version.map_or_else(
+        || "Deprecated in the Redfish schema".to_owned(),
+        |version| format!("Deprecated in the Redfish schema since {version}"),
+    );
+    deprecation.description.map_or_else(
+        || format!("{heading}."),
+        |description| format!("{heading}: {description}"),
+    )
 }
 
 /// Generate muliple lines in doc strings in `TokenStream`.
@@ -95,4 +124,21 @@ fn split_by_lines(s: &str) -> Vec<String> {
         .into_iter()
         .map(|words| " ".to_owned() + &words.join(" "))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deprecation_text;
+    use crate::redfish::Deprecation;
+
+    #[test]
+    fn formats_redfish_deprecation_as_documentation() {
+        assert_eq!(
+            deprecation_text(Deprecation {
+                version: Some("v1_3_0"),
+                description: Some("Use Other for compatibility."),
+            }),
+            "Deprecated in the Redfish schema since v1_3_0: Use Other for compatibility."
+        );
+    }
 }

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -25,6 +25,7 @@ use crate::compiler::PropertyType;
 use crate::compiler::QualifiedName;
 use crate::compiler::RigidArraySupport;
 use crate::generator::rust::doc::format_and_generate as doc_format_and_generate;
+use crate::generator::rust::doc::format_and_generate_with_deprecation as doc_format_deprecated;
 use crate::generator::rust::ActionFullTypeName;
 use crate::generator::rust::ActionName;
 use crate::generator::rust::Config;
@@ -525,7 +526,7 @@ impl<'a> StructDef<'a> {
     }
 
     fn generate_property(p: &Property<'_>, config: &Config) -> TokenStream {
-        let doc = doc_format_and_generate(p.name, &p.odata);
+        let doc = doc_format_deprecated(p.name, &p.odata, p.redfish.deprecation);
         let (serde, field_type) = Self::gen_de_struct_field(
             &p.ptype,
             FullTypeName::new(p.ptype.name(), config),
@@ -626,7 +627,7 @@ impl<'a> StructDef<'a> {
                 if p.odata.permissions_is_write_only() {
                     return TokenStream::new();
                 }
-                let doc = doc_format_and_generate(p.ptype.name(), &p.odata);
+                let doc = doc_format_deprecated(p.ptype.name(), &p.odata, p.redfish.deprecation);
                 let ptype = p.redfish.excerpt_copy.as_ref().map_or_else(
                     || {
                         let full_type = FullTypeName::new(p.ptype.name(), config);
@@ -648,12 +649,16 @@ impl<'a> StructDef<'a> {
                 );
                 (doc, sa, t)
             }
-            NavProperty::Reference(r) => {
-                let doc = TokenStream::new();
+            NavProperty::Reference {
+                cardinality,
+                odata,
+                redfish,
+            } => {
+                let doc = doc_format_deprecated(cardinality.inner(), odata, redfish.deprecation);
                 let top = &config.top_module_alias;
                 let ptype = quote! { #top::ReferenceLeaf };
                 let (sa, t) = Self::gen_de_struct_field(
-                    r,
+                    cardinality,
                     ptype,
                     rename,
                     IsNullable::new(false),

--- a/csdl-compiler/src/odata/annotations.rs
+++ b/csdl-compiler/src/odata/annotations.rs
@@ -159,7 +159,7 @@ pub trait ODataAnnotations {
         self.annotations()
             .iter()
             .find(|a| a.is_odata_annotation("Permissions"))
-            .and_then(|a| a.enum_member.as_ref())
+            .and_then(|a| a.enum_members().next())
             .and_then(|v| match v.mname.inner().inner().as_str() {
                 "ReadWrite" => Some(Permissions::ReadWrite),
                 "Read" => Some(Permissions::Read),

--- a/csdl-compiler/src/redfish/annotations.rs
+++ b/csdl-compiler/src/redfish/annotations.rs
@@ -17,7 +17,9 @@ use crate::edmx::Annotation;
 use crate::edmx::ComplexType;
 use crate::edmx::NavigationProperty;
 use crate::edmx::Parameter;
+use crate::edmx::QualifiedTypeName;
 use crate::edmx::StructuralProperty;
+use crate::redfish::Deprecation;
 use crate::redfish::DynamicProperties;
 use crate::redfish::Excerpt;
 use crate::redfish::ExcerptCopy;
@@ -33,10 +35,53 @@ pub trait RedfishAnnotation {
 
 impl RedfishAnnotation for Annotation {
     fn is_redfish_annotation(&self, name: &str) -> bool {
-        self.term.inner().namespace.ids.len() == 1
-            && self.term.inner().namespace.ids[0].inner() == "Redfish"
-            && self.term.inner().name.inner() == name
+        is_redfish_qualified_name(&self.term, name)
     }
+}
+
+fn is_redfish_qualified_name(qname: &QualifiedTypeName, name: &str) -> bool {
+    qname.inner().namespace.ids.len() == 1
+        && qname.inner().namespace.ids[0].inner() == "Redfish"
+        && qname.inner().name.inner() == name
+}
+
+fn revisions_deprecation(annotations: &[Annotation]) -> Option<Deprecation<'_>> {
+    let records = &annotations
+        .iter()
+        .find(|annotation| annotation.is_redfish_annotation("Revisions"))
+        .and_then(|annotation| annotation.collection.as_ref())?
+        .record;
+
+    records.iter().find_map(|record| {
+        record
+            .property_value("Kind")?
+            .enum_members()
+            .any(|member| {
+                is_redfish_qualified_name(&member.tname, "RevisionKind")
+                    && member.mname.inner().inner() == "Deprecated"
+            })
+            .then(|| {
+                let value = |name| {
+                    record
+                        .property_value(name)
+                        .and_then(|value| value.string_value.as_deref())
+                };
+                Deprecation {
+                    version: value("Version"),
+                    description: value("Description"),
+                }
+            })
+    })
+}
+
+fn legacy_deprecation(annotations: &[Annotation]) -> Option<Deprecation<'_>> {
+    annotations
+        .iter()
+        .find(|annotation| annotation.is_redfish_annotation("Deprecated"))
+        .map(|annotation| Deprecation {
+            version: None,
+            description: annotation.string.as_deref(),
+        })
 }
 
 pub trait RedfishAnnotations {
@@ -102,6 +147,14 @@ pub trait RedfishAnnotations {
             })
     }
 
+    /// Return Redfish deprecation metadata.
+    ///
+    /// `Redfish.Revisions` is the current representation. The legacy
+    /// `Redfish.Deprecated` term remains supported for older schemas.
+    fn deprecation(&self) -> Option<Deprecation<'_>> {
+        revisions_deprecation(self.annotations()).or_else(|| legacy_deprecation(self.annotations()))
+    }
+
     /// Returns if type can contain dynamic properties.
     fn dynamic_properties(&self) -> Option<DynamicProperties<'_>> {
         self.annotations()
@@ -148,5 +201,59 @@ impl RedfishAnnotations for Parameter {
 impl RedfishAnnotations for ComplexType {
     fn annotations(&self) -> &Vec<Annotation> {
         &self.annotations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RedfishAnnotations as _;
+    use crate::edmx::StructuralProperty;
+    use quick_xml::de::from_str;
+
+    #[test]
+    fn reads_current_deprecation_metadata() {
+        let property: StructuralProperty = from_str(
+            r#"
+            <Property Name="EventType" Type="Edm.String" Nullable="false">
+              <Annotation Term="Redfish.Required"/>
+              <Annotation Term="Redfish.Revisions">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                  </Record>
+                  <Record>
+                    <PropertyValue Property="Kind">
+                      <EnumMember>Redfish.RevisionKind/Deprecated</EnumMember>
+                    </PropertyValue>
+                    <PropertyValue Property="Version" String="v1_3_0"/>
+                    <PropertyValue Property="Description" String="Use Other for compatibility."/>
+                  </Record>
+                </Collection>
+              </Annotation>
+            </Property>"#,
+        )
+        .expect("valid property");
+        let deprecation = property.deprecation().expect("deprecation metadata");
+
+        assert_eq!(deprecation.version, Some("v1_3_0"));
+        assert_eq!(
+            deprecation.description,
+            Some("Use Other for compatibility.")
+        );
+        assert!(property.is_required().into_inner());
+    }
+
+    #[test]
+    fn legacy_deprecation_is_supported() {
+        let property: StructuralProperty = from_str(
+            r#"<Property Name="Value" Type="Edm.String">
+                 <Annotation Term="Redfish.Deprecated" String="Use Replacement."/>
+               </Property>"#,
+        )
+        .expect("valid property");
+        let deprecation = property.deprecation().expect("legacy deprecation");
+
+        assert_eq!(deprecation.version, None);
+        assert_eq!(deprecation.description, Some("Use Replacement."));
     }
 }

--- a/csdl-compiler/src/redfish/mod.rs
+++ b/csdl-compiler/src/redfish/mod.rs
@@ -36,3 +36,12 @@ pub struct DynamicProperties<'a> {
     pub pattern: &'a String,
     pub ptype: &'a String,
 }
+
+/// Deprecation metadata attached to a Redfish schema object.
+#[derive(Debug, Clone, Copy)]
+pub struct Deprecation<'a> {
+    /// Schema version in which the object was deprecated.
+    pub version: Option<&'a str>,
+    /// Rationale or replacement guidance supplied by the schema.
+    pub description: Option<&'a str>,
+}

--- a/redfish/src/event_service/mod.rs
+++ b/redfish/src/event_service/mod.rs
@@ -102,7 +102,7 @@ impl<B: Bmc> EventService<B> {
                 sse_event_record_patches.push(patch::patch_missing_event_record_member_id);
             }
             if bmc.quirks.event_service_sse_missing_event_type() {
-                sse_event_record_patches.push(patch::patch_missing_event_type_to_unsupported);
+                sse_event_record_patches.push(patch::patch_missing_event_type_to_other);
             }
             if bmc.quirks.event_service_sse_no_odata_id() {
                 let patch_event_id: ReadPatchFn =

--- a/redfish/src/event_service/patch.rs
+++ b/redfish/src/event_service/patch.rs
@@ -91,14 +91,14 @@ pub(super) fn patch_missing_event_record_member_id(
     );
 }
 
-pub(super) fn patch_missing_event_type_to_unsupported(
+pub(super) fn patch_missing_event_type_to_other(
     value: &mut JsonMap<String, JsonValue>,
     _index: usize,
 ) {
     if value.get("EventType").is_none() {
         value.insert(
             "EventType".to_string(),
-            JsonValue::String("UnsupportedValue".to_string()),
+            JsonValue::String("Other".to_string()),
         );
     }
 }
@@ -147,7 +147,7 @@ mod tests {
     use super::fix_timestamp_offset;
     use super::patch_event_records;
     use super::patch_missing_event_record_member_id;
-    use super::patch_missing_event_type_to_unsupported;
+    use super::patch_missing_event_type_to_other;
     use super::EventRecordPatchFn;
     use serde_json::json;
 
@@ -163,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn inserts_event_type_when_absent() {
+    fn inserts_other_event_type_when_absent() {
         let payload = json!({
             "Events": [
                 {
@@ -179,7 +179,7 @@ mod tests {
 
         let payload = patch_event_records(
             payload,
-            &[patch_missing_event_type_to_unsupported as EventRecordPatchFn],
+            &[patch_missing_event_type_to_other as EventRecordPatchFn],
         );
 
         let events = payload
@@ -190,7 +190,7 @@ mod tests {
             events[0]
                 .get("EventType")
                 .and_then(serde_json::Value::as_str),
-            Some("UnsupportedValue")
+            Some("Other")
         );
         assert_eq!(
             events[1]

--- a/tests/tests/test-vera-rubin.rs
+++ b/tests/tests/test-vera-rubin.rs
@@ -107,7 +107,7 @@ async fn vera_rubin_sse_accepts_missing_and_present_event_type() -> Result<(), B
         .get(bmc.as_ref())
         .await?;
 
-    assert_eq!(patched.event_type, EventType::UnsupportedValue);
+    assert_eq!(patched.event_type, EventType::Other);
     assert_eq!(preserved.event_type, EventType::Alert);
 
     Ok(())


### PR DESCRIPTION
Depricated fields are annotation only, this PR carries this annotations into generated code docstrings.

Also fixes small issue with EventType mapping to Other unstead of Unspecified  ref: https://redfishforum.com/thread/1315/deprecation-handling