### PR TITLE
fix(ci): unshallow submodules before merge-base checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           sudo apt-get install -y valgrind
           valgrind --version
 
+      - name: Unshallow submodules
+        # actions/checkout fetches only the pinned submodule commit; older
+        # commits (e.g. the pre-PR schema pointer) are absent. Unshallow
+        # every submodule so the base-commit checkout below can resolve them.
+        run: git submodule foreach 'git fetch --unshallow 2>/dev/null || git fetch'
+
       - name: Benchmark merge-base
         # Installs the runner matching the *base* lockfile, so a PR that
         # bumps gungraun still measures the base correctly. Only the


### PR DESCRIPTION
The bench-regression job checks out the merge-base commit with --recurse-submodules to run benchmarks at the baseline. When a PR updates a submodule pointer, actions/checkout only fetches the commit referenced by HEAD; the older commit the merge-base needs is absent from the local submodule repo, causing the checkout to fail.

Unshallow every submodule before the base-commit checkout so all referenced commits are available locally.
