### PR TITLE
ci: repin dsx GitHub Actions after org transfer

### DIFF
--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -17,8 +17,8 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
-        # Refer to https://github.com/NVIDIA/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
+        # Refer to https://github.com/dsx-ai-factory/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
         with:
           days-before-issue-stale: '60'
           days-before-pr-stale: '30'


### PR DESCRIPTION
## Summary

- repin the `NVIDIA/dsx-github-actions` stale-check action to `dsx-ai-factory/dsx-github-actions`
- preserve the action path and immutable commit SHA
- update the adjacent documentation link to the transferred repository

## Tracking

- NvBug: https://nvbugspro.nvidia.com/bug/6528755

## Validation

- `git diff --check`
- confirmed no exact `NVIDIA/dsx-github-actions` references remain
- confirmed the committed diff changes only the repository owner/path

## Merge timing

Keep this PR as a draft and merge it only after the repository transfer to `dsx-ai-factory/dsx-github-actions` is complete and the new location is available.
