### PR TITLE
feat: csdl-compiler steps API

### DIFF
--- a/csdl-compiler/src/query.rs
+++ b/csdl-compiler/src/query.rs
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Schema queries for projection compilers.
+//! Schema queries for projection compilers: [`SchemaQuery::resolve`]
+//! answers what a path *is*, [`SchemaQuery::steps`] additionally answers
+//! how generated Rust reaches it, segment by segment.
 
 use std::collections::HashMap;
 
@@ -39,6 +41,45 @@ pub struct ResolvedProperty<'a> {
     pub nullable: bool,
     pub collection: bool,
     pub enum_members: Option<Vec<&'a EnumMemberName>>,
+}
+
+/// One segment of a resolved property path.
+///
+/// The last step is the leaf, carrying the same facts
+/// [`SchemaQuery::resolve`] reports; every step additionally carries what
+/// generated field access needs — the declaring type's distance up the
+/// base chain, `Redfish.Required`, and a type definition's underlying
+/// primitive.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Step<'a> {
+    /// The property's type after the fold.
+    pub type_name: QualifiedName<'a>,
+    pub class: TypeClass,
+    pub nullable: bool,
+    pub collection: bool,
+    /// `Redfish.Required` on the property.
+    pub required: bool,
+    /// Base-chain hops from the holding type to the type declaring the
+    /// property, in the optimizer-collapsed chain — the count of `base`
+    /// accesses generated field access puts in front of the field.
+    pub hops: usize,
+    /// For a type definition, the primitive underneath.
+    pub underlying: Option<QualifiedName<'a>>,
+    /// Members when the type is an enum.
+    pub enum_members: Option<Vec<&'a EnumMemberName>>,
+}
+
+impl<'a> From<Step<'a>> for ResolvedProperty<'a> {
+    fn from(leaf: Step<'a>) -> Self {
+        Self {
+            type_name: leaf.type_name,
+            class: leaf.class,
+            nullable: leaf.nullable,
+            collection: leaf.collection,
+            enum_members: leaf.enum_members,
+        }
+    }
 }
 
 /// A queryable view over a compiled bundle.
@@ -77,38 +118,66 @@ impl<'a> SchemaQuery<'a> {
     /// Whether the bundle declares an entity type of this name.
     #[must_use]
     pub fn has_entity(&self, name: &str) -> bool {
-        self.entities.contains_key(name)
+        self.entity(name).is_some()
+    }
+
+    /// The qualified name the index picked for an entity short name: the
+    /// schema family rooted at the name at its highest version when one
+    /// exists, otherwise the highest-ranked declaration of the name.
+    #[must_use]
+    pub fn entity(&self, name: &str) -> Option<QualifiedName<'a>> {
+        self.entities.get(name).copied()
     }
 
     /// Resolves a dotted property path against the named entity type,
-    /// descending through complex types and walking base chains.
+    /// descending through singular complex types and walking base chains.
     #[must_use]
     pub fn resolve(&self, entity: &str, path: &str) -> Option<ResolvedProperty<'a>> {
+        self.steps(entity, path)?.pop().map(Into::into)
+    }
+
+    /// Resolves a dotted property path into one step per segment.
+    #[must_use]
+    pub fn steps(&self, entity: &str, path: &str) -> Option<Vec<Step<'a>>> {
         let mut current = TypeRef::Entity(*self.entities.get(entity)?);
+        let mut steps = Vec::new();
         let mut segments = path.split('.').peekable();
         while let Some(segment) = segments.next() {
-            let property = self.property_of(current, segment)?;
+            let (property, hops) = self.property_of(current, segment)?;
             let ((info, qname), collection) = match &property.ptype {
                 OneOrCollection::One(inner) => (inner, false),
                 OneOrCollection::Collection(inner) => (inner, true),
             };
             let (class, qname) = (info.class, *qname);
-            if segments.peek().is_none() {
-                let enum_members = match class {
+            let enum_members =
+                match class {
                     TypeClass::EnumType => self.compiled.enum_types.get(&qname).map(|declared| {
                         declared.members.iter().map(|member| member.name).collect()
                     }),
                     _ => None,
                 };
-                return Some(ResolvedProperty {
-                    type_name: qname,
-                    class,
-                    nullable: property.nullable.into_inner(),
-                    collection,
-                    enum_members,
-                });
+            let underlying = match class {
+                TypeClass::TypeDefinition => self
+                    .compiled
+                    .type_definitions
+                    .get(&qname)
+                    .map(|definition| definition.underlying_type),
+                _ => None,
+            };
+            steps.push(Step {
+                type_name: qname,
+                class,
+                nullable: property.nullable.into_inner(),
+                collection,
+                required: property.redfish.is_required.into_inner(),
+                hops,
+                underlying,
+                enum_members,
+            });
+            if segments.peek().is_none() {
+                return Some(steps);
             }
-            if class != TypeClass::ComplexType {
+            if class != TypeClass::ComplexType || collection {
                 return None;
             }
             current = TypeRef::Complex(qname);
@@ -116,16 +185,19 @@ impl<'a> SchemaQuery<'a> {
         None
     }
 
-    /// The named structural property, searched up the base chain.
-    fn property_of(&self, mut tref: TypeRef<'a>, name: &str) -> Option<&Property<'a>> {
+    /// The named structural property with the number of base-chain hops
+    /// that reached it.
+    fn property_of(&self, mut tref: TypeRef<'a>, name: &str) -> Option<(&Property<'a>, usize)> {
+        let mut hops = 0;
         while let Some((properties, base)) = self.declaration(tref) {
             if let Some(property) = properties
                 .properties
                 .iter()
                 .find(|property| property.name.inner().inner() == name)
             {
-                return Some(property);
+                return Some((property, hops));
             }
+            hops += 1;
             tref = match tref {
                 TypeRef::Entity(_) => TypeRef::Entity(base?),
                 TypeRef::Complex(_) => TypeRef::Complex(base?),
@@ -228,6 +300,7 @@ mod test {
                 <Member Name="OK"/>
                 <Member Name="Warning"/>
               </EnumType>
+              <TypeDefinition Name="Label" UnderlyingType="Edm.String"/>
             </Schema>
             <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings">
               <ComplexType Name="Settings"/>
@@ -240,11 +313,15 @@ mod test {
               <EntityType Name="Widget" BaseType="Widget.Widget">
                 <Property Name="Reading" Type="Edm.Decimal" Nullable="true"/>
                 <Property Name="Status" Type="Resource.Status" Nullable="false"/>
+                <Property Name="Tag" Type="Resource.Label" Nullable="false">
+                  <Annotation Term="Redfish.Required"/>
+                </Property>
               </EntityType>
             </Schema>
             <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Widget.v1_1_0">
               <EntityType Name="Widget" BaseType="Widget.v1_0_0.Widget">
                 <Property Name="Labels" Type="Collection(Edm.String)" Nullable="false"/>
+                <Property Name="Slots" Type="Collection(Resource.Status)" Nullable="false"/>
               </EntityType>
             </Schema>
             <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Widget.v1_10_0">
@@ -326,5 +403,60 @@ mod test {
         // Unknown paths and descent through scalars resolve to nothing.
         assert!(query.resolve("Widget", "Readng").is_none());
         assert!(query.resolve("Widget", "Reading.Deeper").is_none());
+    }
+
+    #[test]
+    fn steps_expose_per_segment_emission_facts() {
+        let bundle = bundle();
+        let query = SchemaQuery::build(&bundle).expect("bundle compiles");
+
+        // The pick behind every walk is addressable by short name; its
+        // namespace after the fold spells the generated module.
+        let widget = query.entity("Widget").expect("Widget is indexed");
+        assert_eq!(widget.namespace.to_string(), "Widget");
+        assert!(query.entity("Gadget").is_none());
+
+        // A leaf on the fold itself: no hops. One declared on a base:
+        // as many hops as generated field access spells `base`.
+        let reading = query.steps("Widget", "Reading").expect("Reading resolves");
+        assert_eq!(reading.len(), 1);
+        assert_eq!(reading[0].hops, 0);
+        assert!(!reading[0].required);
+        let id = query.steps("Widget", "Id").expect("Id resolves");
+        assert_eq!(id[0].hops, 1);
+
+        // A required type definition: the annotation and the underlying
+        // primitive, neither of which the leaf view reports.
+        let tag = query.steps("Widget", "Tag").expect("Tag resolves");
+        assert!(tag[0].required);
+        assert!(!tag[0].nullable);
+        assert_eq!(tag[0].class, TypeClass::TypeDefinition);
+        let underlying = tag[0].underlying.expect("a typedef has an underlying type");
+        assert_eq!(underlying.to_string(), "Edm.String");
+
+        // Every segment reports, not only the leaf; the leaf agrees with
+        // `resolve` because it is `resolve`.
+        let steps = query
+            .steps("Widget", "Status.Health")
+            .expect("Status.Health resolves");
+        assert_eq!(steps.len(), 2);
+        assert_eq!(steps[0].class, TypeClass::ComplexType);
+        assert_eq!(steps[0].hops, 0);
+        assert!(!steps[0].nullable);
+        assert!(steps[1].nullable);
+        let leaf = query
+            .resolve("Widget", "Status.Health")
+            .expect("Status.Health resolves");
+        assert_eq!(leaf.type_name, steps[1].type_name);
+        assert_eq!(
+            leaf.enum_members.expect("Health is an enum").len(),
+            steps[1].enum_members.as_ref().expect("same walk").len()
+        );
+
+        // A collection leaf is addressable; descent through one is not —
+        // its element is no property holder in generated Rust.
+        assert!(query.steps("Widget", "Slots").is_some());
+        assert!(query.steps("Widget", "Slots.Health").is_none());
+        assert!(query.resolve("Widget", "Slots.Health").is_none());
     }
 }

--- a/csdl-compiler/src/query.rs
+++ b/csdl-compiler/src/query.rs
@@ -13,9 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Schema queries for projection compilers: [`SchemaQuery::resolve`]
-//! answers what a path *is*, [`SchemaQuery::steps`] additionally answers
-//! how generated Rust reaches it, segment by segment.
+//! Schema queries for projection compilers.
+//!
+//! [`SchemaQuery::resolve`] answers what a path *is*; [`SchemaQuery::steps`]
+//! additionally answers how generated Rust reaches it, segment by segment.
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
Add new public API for query in csdl-compiler called `steps`, API allow tracing of the how compiler reaches specific properties.