### PR TITLE
fix: complex-type recursion

### DIFF
--- a/csdl-compiler/src/compiler/complex_type.rs
+++ b/csdl-compiler/src/compiler/complex_type.rs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::compiler::compile_type;
+use crate::compiler::ensure_type;
+use crate::compiler::is_simple_type;
 use crate::compiler::Compiled;
 use crate::compiler::Context;
 use crate::compiler::Error;
@@ -95,22 +96,29 @@ pub(crate) fn compile<'a>(
     ctx: &Context<'a>,
     stack: &Stack<'a, '_>,
 ) -> Result<(Compiled<'a>, TypeInfo), Error<'a>> {
-    let name = qtype;
+    // The frame marks this type as in progress before anything recurses,
+    // so a self-referential property terminates instead of compiling its
+    // own type forever.
+    let stack = stack.new_frame().with_complex_type(qtype);
     // Ensure that the base complex type is compiled, if present.
-    let (base, compiled) = if let Some(base_type) = &ct.base_type {
-        let (compiled, _) = compile_type(base_type.into(), ctx, stack)?;
-        (Some(base_type.into()), compiled)
+    // `ensure_type` short-circuits `Edm.*`, so an invalid simple-type
+    // base is rejected here to stay a schema-time error.
+    let (base, stack) = if let Some(base_type) = &ct.base_type {
+        let base: QualifiedName = base_type.into();
+        if is_simple_type(base) {
+            return Err(Error::TypeNotFound(base));
+        }
+        let (compiled, _) = ensure_type(base, ctx, &stack)?;
+        (Some(base), stack.merge(compiled))
     } else {
-        (None, Compiled::default())
+        (None, stack)
     };
-
-    let stack = stack.new_frame().merge(compiled);
 
     let (compiled, properties) =
         Properties::compile(qtype, &ct.properties, ctx, stack.new_frame())?;
 
     let complex_type = ComplexType {
-        name,
+        name: qtype,
         base,
         properties,
         odata: OData::new(MustHaveId::new(false), ct),

--- a/csdl-compiler/src/compiler/error.rs
+++ b/csdl-compiler/src/compiler/error.rs
@@ -41,6 +41,11 @@ pub enum Error<'a> {
     /// A single-valued property closes a complex-type reference cycle,
     /// which generated Rust cannot represent without indirection.
     UnrepresentableCycle(QualifiedName<'a>),
+    /// A reference cycle spans more than one complex type — through
+    /// properties, a base, or both. Only direct self-reference is
+    /// supported: a wider cycle would bake one member's provisional type
+    /// info into another's compiled form.
+    UnsupportedCycle(QualifiedName<'a>),
     /// Settings.Settings type was not found.
     SettingsTypeNotFound,
     /// Settings.PreferredApplyTime type was not found.
@@ -90,8 +95,13 @@ impl Display for Error<'_> {
             }
             Self::UnrepresentableCycle(v) => write!(
                 f,
-                "single-valued property closes a reference cycle through {v}; \
-                 only collection-valued cycle edges are representable"
+                "single-valued property references its own type {v}, which \
+                 generated Rust cannot represent without indirection"
+            ),
+            Self::UnsupportedCycle(v) => write!(
+                f,
+                "complex-type reference cycle through {v}; only direct \
+                 self-reference is supported"
             ),
             Self::SettingsTypeNotFound => write!(
                 f,

--- a/csdl-compiler/src/compiler/error.rs
+++ b/csdl-compiler/src/compiler/error.rs
@@ -38,6 +38,9 @@ pub enum Error<'a> {
     ComplexTypeNotFound(QualifiedName<'a>),
     /// A cycle was found in type inheritance.
     CyclicType(Vec<QualifiedName<'a>>),
+    /// A single-valued property closes a complex-type reference cycle,
+    /// which generated Rust cannot represent without indirection.
+    UnrepresentableCycle(QualifiedName<'a>),
     /// Settings.Settings type was not found.
     SettingsTypeNotFound,
     /// Settings.PreferredApplyTime type was not found.
@@ -85,6 +88,11 @@ impl Display for Error<'_> {
                     write!(f, "{qtype}")
                 })
             }
+            Self::UnrepresentableCycle(v) => write!(
+                f,
+                "single-valued property closes a reference cycle through {v}; \
+                 only collection-valued cycle edges are representable"
+            ),
             Self::SettingsTypeNotFound => write!(
                 f,
                 "cannot find type for Redfish settings (Settings.Settings)"

--- a/csdl-compiler/src/compiler/mod.rs
+++ b/csdl-compiler/src/compiler/mod.rs
@@ -339,7 +339,7 @@ impl SchemaBundle {
     }
 
     fn root_set_all(&self) -> RootSet<'_> {
-        let entity_types = self
+        let mut entity_types: Vec<_> = self
             .edmx_docs
             .iter()
             .take(self.root_set_threshold.unwrap_or(self.edmx_docs.len()))
@@ -356,7 +356,7 @@ impl SchemaBundle {
                     .collect::<Vec<_>>()
             })
             .collect();
-        let complex_types = self
+        let mut complex_types: Vec<_> = self
             .edmx_docs
             .iter()
             .take(self.root_set_threshold.unwrap_or(self.edmx_docs.len()))
@@ -379,6 +379,12 @@ impl SchemaBundle {
                     .collect::<Vec<_>>()
             })
             .collect();
+        // Schemas store types in hash maps, and iteration order must not
+        // decide compile order: which member of a reference cycle sees
+        // the provisional type info — and with it generated output —
+        // would otherwise vary run to run.
+        entity_types.sort_unstable();
+        complex_types.sort_unstable();
         RootSet {
             entity_types,
             complex_types,
@@ -476,6 +482,24 @@ fn ensure_type<'a>(
         Ok((Compiled::default(), TypeInfo::simple_type()))
     } else if let Some(info) = stack.complex_type_info(qtype) {
         Ok((Compiled::default(), info))
+    } else if stack.compiling_complex_type(qtype) {
+        // A self-referential complex type sees the type it is inside of
+        // rather than compiling it again forever. The shipped shape is
+        // `AttributeRegistry.v1_5_0.MapFrom`, whose `Subexpressions`
+        // declares `Collection(v1_0_0.MapFrom)` and becomes
+        // self-referential only when `find_child_type` resolves the base
+        // version down to v1_5_0 — the guard must therefore match the
+        // resolved name, never the declared one. Provisional permissions
+        // stay `None`, the permissive reading: the enclosing type is
+        // never classified read-only on account of a self-reference, so
+        // Update structs are generated rather than silently dropped.
+        Ok((
+            Compiled::default(),
+            TypeInfo {
+                class: TypeClass::ComplexType,
+                permissions: None,
+            },
+        ))
     } else if stack.contains_type_definition(qtype) {
         Ok((Compiled::default(), TypeInfo::type_definition()))
     } else if stack.contains_enum_type(qtype) {
@@ -531,6 +555,168 @@ mod test {
                     if cycle.len() >= 2 && cycle.first() == cycle.last()
             ),
             "compile_all must propagate the closed inheritance cycle"
+        );
+    }
+
+    /// `compile_all` unconditionally compiles the Redfish framework
+    /// types, so every fixture carries minimal Resource and Settings
+    /// declarations beside the fragment under test.
+    fn scaffolded(fragment: &str) -> SchemaBundle {
+        let schema = format!(
+            r#"<edmx:Edmx Version="4.0">
+             <edmx:DataServices>
+               {fragment}
+               <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource">
+                 <EntityType Name="Resource" Abstract="true"/>
+                 <EntityType Name="ResourceCollection" Abstract="true"/>
+               </Schema>
+               <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings">
+                 <ComplexType Name="Settings"/>
+                 <ComplexType Name="PreferredApplyTime"/>
+               </Schema>
+             </edmx:DataServices>
+           </edmx:Edmx>"#
+        );
+        SchemaBundle {
+            edmx_docs: vec![Edmx::parse(&schema).expect("fixture schema must be valid")],
+            root_set_threshold: None,
+        }
+    }
+
+    fn has_complex_type(compiled: &Compiled<'_>, name: &str) -> bool {
+        let qname: QualifiedTypeName = name.parse().expect("a qualified type name");
+        compiled.complex_types.contains_key(&(&qname).into())
+    }
+
+    #[test]
+    fn a_self_referential_complex_type_compiles() {
+        // A collection of the enclosing type terminates: the guard hands
+        // the self-referential property provisional type info instead of
+        // compiling its own type forever.
+        let bundle = scaffolded(
+            r#"<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Registry">
+                 <EntityType Name="Registry">
+                   <Property Name="Dependency" Type="Registry.MapFrom" Nullable="false"/>
+                 </EntityType>
+                 <ComplexType Name="MapFrom">
+                   <Property Name="Subexpressions" Type="Collection(Registry.MapFrom)" Nullable="false"/>
+                 </ComplexType>
+               </Schema>"#,
+        );
+        let compiled = bundle
+            .compile_all(Config::default())
+            .expect("a self-referential complex type terminates");
+        let qname: QualifiedTypeName = "Registry.MapFrom".parse().expect("a qualified type name");
+        let map_from = compiled
+            .complex_types
+            .get(&(&qname).into())
+            .expect("MapFrom compiled");
+        // The provisional info pins the permissive reading: the enclosing
+        // type is never classified read-only on account of its
+        // self-reference, so an Update struct is generated for it.
+        assert_eq!(TypeInfo::complex_type(map_from).permissions, None);
+        assert!(map_from.generates_update());
+    }
+
+    #[test]
+    fn a_derived_type_self_referential_through_its_base_compiles() {
+        // The shipped AttributeRegistry v1.5.0 shape: `Subexpressions`
+        // declares the BASE version's name, and only becomes
+        // self-referential when `find_child_type` resolves it down to the
+        // derived type. A guard matching the declared name instead of the
+        // resolved one would hang on exactly this fixture.
+        let bundle = scaffolded(
+            r#"<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Registry">
+                 <EntityType Name="Registry">
+                   <Property Name="Dependency" Type="Registry.v1_0_0.MapFrom" Nullable="false"/>
+                 </EntityType>
+               </Schema>
+               <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Registry.v1_0_0">
+                 <ComplexType Name="MapFrom">
+                   <Property Name="Tag" Type="Edm.String" Nullable="false"/>
+                 </ComplexType>
+               </Schema>
+               <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Registry.v1_5_0">
+                 <ComplexType Name="MapFrom" BaseType="Registry.v1_0_0.MapFrom">
+                   <Property Name="Subexpressions" Type="Collection(Registry.v1_0_0.MapFrom)" Nullable="false"/>
+                 </ComplexType>
+               </Schema>"#,
+        );
+        let compiled = bundle
+            .compile_all(Config::default())
+            .expect("the base-declared self-reference terminates");
+        assert!(has_complex_type(&compiled, "Registry.v1_5_0.MapFrom"));
+    }
+
+    #[test]
+    fn mutually_referential_complex_types_compile_through_collections() {
+        let bundle = scaffolded(
+            r#"<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Pair">
+                 <EntityType Name="Pair">
+                   <Property Name="First" Type="Pair.A" Nullable="false"/>
+                 </EntityType>
+                 <ComplexType Name="A">
+                   <Property Name="Others" Type="Collection(Pair.B)" Nullable="false"/>
+                 </ComplexType>
+                 <ComplexType Name="B">
+                   <Property Name="Others" Type="Collection(Pair.A)" Nullable="false"/>
+                 </ComplexType>
+               </Schema>"#,
+        );
+        let compiled = bundle
+            .compile_all(Config::default())
+            .expect("collection-valued mutual references terminate");
+        assert!(has_complex_type(&compiled, "Pair.A"));
+        assert!(has_complex_type(&compiled, "Pair.B"));
+    }
+
+    #[test]
+    fn a_single_valued_reference_cycle_is_refused() {
+        // A struct cannot contain itself without indirection, and the
+        // generator has none: a cycle closed by single-valued properties
+        // must fail at schema time rather than emit Rust that cannot
+        // compile.
+        let bundle = scaffolded(
+            r#"<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Pair">
+                 <EntityType Name="Pair">
+                   <Property Name="First" Type="Pair.A" Nullable="false"/>
+                 </EntityType>
+                 <ComplexType Name="A">
+                   <Property Name="Other" Type="Pair.B" Nullable="false"/>
+                 </ComplexType>
+                 <ComplexType Name="B">
+                   <Property Name="Other" Type="Pair.A" Nullable="false"/>
+                 </ComplexType>
+               </Schema>"#,
+        );
+        let error = bundle
+            .compile_all(Config::default())
+            .expect_err("a single-valued cycle is refused");
+        assert!(
+            format!("{error:?}").contains("UnrepresentableCycle"),
+            "the error names the unrepresentable cycle: {error:?}"
+        );
+    }
+
+    #[test]
+    fn a_complex_type_with_a_simple_base_is_refused() {
+        // `ensure_type` short-circuits `Edm.*`, so the base check keeps
+        // an invalid base a schema-time error rather than an unresolved
+        // path in the generated crate.
+        let bundle = scaffolded(
+            r#"<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Bad">
+                 <EntityType Name="Bad">
+                   <Property Name="Value" Type="Bad.X" Nullable="false"/>
+                 </EntityType>
+                 <ComplexType Name="X" BaseType="Edm.String"/>
+               </Schema>"#,
+        );
+        let error = bundle
+            .compile_all(Config::default())
+            .expect_err("a simple-type base is refused");
+        assert!(
+            format!("{error:?}").contains("TypeNotFound"),
+            "the error names the missing base: {error:?}"
         );
     }
 

--- a/csdl-compiler/src/compiler/mod.rs
+++ b/csdl-compiler/src/compiler/mod.rs
@@ -483,23 +483,36 @@ fn ensure_type<'a>(
     } else if let Some(info) = stack.complex_type_info(qtype) {
         Ok((Compiled::default(), info))
     } else if stack.compiling_complex_type(qtype) {
-        // A self-referential complex type sees the type it is inside of
-        // rather than compiling it again forever. The shipped shape is
-        // `AttributeRegistry.v1_5_0.MapFrom`, whose `Subexpressions`
-        // declares `Collection(v1_0_0.MapFrom)` and becomes
-        // self-referential only when `find_child_type` resolves the base
-        // version down to v1_5_0 — the guard must therefore match the
-        // resolved name, never the declared one. Provisional permissions
-        // stay `None`, the permissive reading: the enclosing type is
-        // never classified read-only on account of a self-reference, so
-        // Update structs are generated rather than silently dropped.
-        Ok((
-            Compiled::default(),
-            TypeInfo {
-                class: TypeClass::ComplexType,
-                permissions: None,
-            },
-        ))
+        if stack.nearest_complex_type() == Some(qtype) {
+            // A directly self-referential complex type sees the type it is
+            // inside of rather than compiling it again forever. The shipped
+            // shape is `AttributeRegistry.v1_5_0.MapFrom`, whose
+            // `Subexpressions` declares `Collection(v1_0_0.MapFrom)` and
+            // becomes self-referential only when `find_child_type` resolves
+            // the base version down to v1_5_0 — the guard must therefore
+            // match the resolved name, never the declared one. Provisional
+            // permissions stay `None`, the permissive reading: the type is
+            // never classified read-only on account of a self-reference, so
+            // its own Update struct is generated rather than silently
+            // dropped — and because the reference is to itself, that struct
+            // always exists.
+            Ok((
+                Compiled::default(),
+                TypeInfo {
+                    class: TypeClass::ComplexType,
+                    permissions: None,
+                },
+            ))
+        } else {
+            // A cycle spanning more than one complex type — through
+            // properties, a base, or both — would bake one member's
+            // provisional info into another's compiled form: dangling
+            // Update references, order-dependent output, and by-value
+            // base embedding the generator has no layout for. No shipped
+            // schema declares one; refuse loudly instead of emitting
+            // Rust that cannot compile.
+            Err(Error::UnsupportedCycle(qtype))
+        }
     } else if stack.contains_type_definition(qtype) {
         Ok((Compiled::default(), TypeInfo::type_definition()))
     } else if stack.contains_enum_type(qtype) {
@@ -649,7 +662,10 @@ mod test {
     }
 
     #[test]
-    fn mutually_referential_complex_types_compile_through_collections() {
+    fn a_cycle_spanning_two_complex_types_is_refused() {
+        // Even collection-valued: a wider cycle would bake one member's
+        // provisional type info into the other's compiled form, and which
+        // member that is would follow compile order.
         let bundle = scaffolded(
             r#"<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Pair">
                  <EntityType Name="Pair">
@@ -663,19 +679,22 @@ mod test {
                  </ComplexType>
                </Schema>"#,
         );
-        let compiled = bundle
+        let error = bundle
             .compile_all(Config::default())
-            .expect("collection-valued mutual references terminate");
-        assert!(has_complex_type(&compiled, "Pair.A"));
-        assert!(has_complex_type(&compiled, "Pair.B"));
+            .expect_err("a two-type cycle is refused");
+        assert!(
+            format!("{error:?}").contains("UnsupportedCycle"),
+            "the error names the unsupported cycle: {:?}",
+            error
+        );
     }
 
     #[test]
-    fn a_single_valued_reference_cycle_is_refused() {
-        // A struct cannot contain itself without indirection, and the
-        // generator has none: a cycle closed by single-valued properties
-        // must fail at schema time rather than emit Rust that cannot
-        // compile.
+    fn a_cycle_closed_through_a_base_type_is_refused() {
+        // The by-value base edge closes the cycle here: B embeds A as its
+        // base while A holds B. Inheritance-cycle detection cannot see it
+        // (B -> A is not an inheritance loop), so the in-progress guard
+        // must.
         let bundle = scaffolded(
             r#"<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Pair">
                  <EntityType Name="Pair">
@@ -684,17 +703,41 @@ mod test {
                  <ComplexType Name="A">
                    <Property Name="Other" Type="Pair.B" Nullable="false"/>
                  </ComplexType>
-                 <ComplexType Name="B">
-                   <Property Name="Other" Type="Pair.A" Nullable="false"/>
+                 <ComplexType Name="B" BaseType="Pair.A"/>
+               </Schema>"#,
+        );
+        let error = bundle
+            .compile_all(Config::default())
+            .expect_err("a base-closed cycle is refused");
+        assert!(
+            format!("{error:?}").contains("UnsupportedCycle"),
+            "the error names the unsupported cycle: {:?}",
+            error
+        );
+    }
+
+    #[test]
+    fn a_single_valued_self_reference_is_refused() {
+        // A struct cannot contain itself without indirection, and the
+        // generator has none: only a collection-valued self-reference has
+        // a representation.
+        let bundle = scaffolded(
+            r#"<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Pair">
+                 <EntityType Name="Pair">
+                   <Property Name="First" Type="Pair.A" Nullable="false"/>
+                 </EntityType>
+                 <ComplexType Name="A">
+                   <Property Name="Inner" Type="Pair.A" Nullable="false"/>
                  </ComplexType>
                </Schema>"#,
         );
         let error = bundle
             .compile_all(Config::default())
-            .expect_err("a single-valued cycle is refused");
+            .expect_err("a single-valued self-reference is refused");
         assert!(
             format!("{error:?}").contains("UnrepresentableCycle"),
-            "the error names the unrepresentable cycle: {error:?}"
+            "the error names the unrepresentable self-reference: {:?}",
+            error
         );
     }
 
@@ -716,7 +759,8 @@ mod test {
             .expect_err("a simple-type base is refused");
         assert!(
             format!("{error:?}").contains("TypeNotFound"),
-            "the error names the missing base: {error:?}"
+            "the error names the missing base: {:?}",
+            error
         );
     }
 

--- a/csdl-compiler/src/compiler/properties.rs
+++ b/csdl-compiler/src/compiler/properties.rs
@@ -62,14 +62,25 @@ impl<'a> Properties<'a> {
             .try_fold((stack, Properties::default()), |(stack, mut p), sp| {
                 let stack = match &sp.attrs {
                     PropertyAttrs::StructuralProperty(v) => {
-                        let (compiled, typeinfo) = ensure_type(
-                            ctx.schema_index
-                                .find_child_type(v.ptype.qualified_type_name().into()),
-                            ctx,
-                            &stack,
-                        )
-                        .map_err(Box::new)
-                        .map_err(|e| Error::Property(&sp.name, e))?;
+                        let resolved = ctx
+                            .schema_index
+                            .find_child_type(v.ptype.qualified_type_name().into());
+                        // A single-valued property closing a reference cycle
+                        // has no representation in generated Rust — a struct
+                        // cannot contain itself without indirection — so it
+                        // is refused loudly here. A `Collection` edge is the
+                        // representable shape.
+                        if matches!(v.ptype, OneOrCollection::One(_))
+                            && stack.compiling_complex_type(resolved)
+                        {
+                            return Err(Error::Property(
+                                &sp.name,
+                                Box::new(Error::UnrepresentableCycle(resolved)),
+                            ));
+                        }
+                        let (compiled, typeinfo) = ensure_type(resolved, ctx, &stack)
+                            .map_err(Box::new)
+                            .map_err(|e| Error::Property(&sp.name, e))?;
                         p.properties.push(Property {
                             name: &v.name,
                             ptype: v.ptype.as_ref().map(|t| (typeinfo, t.into())),

--- a/csdl-compiler/src/compiler/properties.rs
+++ b/csdl-compiler/src/compiler/properties.rs
@@ -65,13 +65,14 @@ impl<'a> Properties<'a> {
                         let resolved = ctx
                             .schema_index
                             .find_child_type(v.ptype.qualified_type_name().into());
-                        // A single-valued property closing a reference cycle
-                        // has no representation in generated Rust — a struct
-                        // cannot contain itself without indirection — so it
-                        // is refused loudly here. A `Collection` edge is the
-                        // representable shape.
+                        // A single-valued self-reference has no
+                        // representation in generated Rust — a struct cannot
+                        // contain itself without indirection — so it is
+                        // refused loudly here. A `Collection` edge is the
+                        // representable shape; cycles through other types
+                        // are refused wholesale by `ensure_type`.
                         if matches!(v.ptype, OneOrCollection::One(_))
-                            && stack.compiling_complex_type(resolved)
+                            && stack.nearest_complex_type() == Some(resolved)
                         {
                             return Err(Error::Property(
                                 &sp.name,

--- a/csdl-compiler/src/compiler/stack.rs
+++ b/csdl-compiler/src/compiler/stack.rs
@@ -71,11 +71,29 @@ impl<'a, 'stack> Stack<'a, 'stack> {
     }
 
     /// Check whether a complex type is currently being compiled in this
-    /// frame or any parent frame.
+    /// frame or any parent frame, without crossing an entity frame: an
+    /// entity is referenced by link, so a chain passing through one is
+    /// not a by-value embedding and must not count as a cycle.
     #[must_use]
     pub fn compiling_complex_type(&self, qtype: QualifiedName<'a>) -> bool {
-        matches!(self.in_progress, Some(InProgress::Complex(v)) if v == qtype)
-            || self.parent.is_some_and(|p| p.compiling_complex_type(qtype))
+        match self.in_progress {
+            Some(InProgress::Entity(_)) => false,
+            Some(InProgress::Complex(v)) if v == qtype => true,
+            _ => self.parent.is_some_and(|p| p.compiling_complex_type(qtype)),
+        }
+    }
+
+    /// The complex type whose declaration is being compiled in the
+    /// nearest enclosing frame, without crossing an entity frame. A
+    /// reference to exactly this type is a direct self-reference; a
+    /// reference to any farther in-progress type spans multiple types.
+    #[must_use]
+    pub fn nearest_complex_type(&self) -> Option<QualifiedName<'a>> {
+        match self.in_progress {
+            Some(InProgress::Entity(_)) => None,
+            Some(InProgress::Complex(v)) => Some(v),
+            None => self.parent.and_then(Self::nearest_complex_type),
+        }
     }
 
     /// Check that entity this has been compiled or is being compiled.

--- a/csdl-compiler/src/compiler/stack.rs
+++ b/csdl-compiler/src/compiler/stack.rs
@@ -17,6 +17,18 @@ use crate::compiler::Compiled;
 use crate::compiler::QualifiedName;
 use crate::compiler::TypeInfo;
 
+/// The type a frame is currently compiling; a recursive reference to it
+/// must terminate instead of compiling it again. What termination means
+/// differs by class: entities are referenced by link, so the reference
+/// just resolves to the name, while complex types embed by value, so a
+/// reference needs provisional type info and a single-valued edge is
+/// refused as unrepresentable.
+#[derive(Clone, Copy)]
+enum InProgress<'a> {
+    Entity(QualifiedName<'a>),
+    Complex(QualifiedName<'a>),
+}
+
 /// Compilation stack. Created when recursing to compile nested types.
 ///
 /// Note: never return `Stack` frames from helper functions. Instead,
@@ -25,9 +37,7 @@ use crate::compiler::TypeInfo;
 #[derive(Default)]
 pub struct Stack<'a, 'stack> {
     parent: Option<&'stack Self>,
-    // If entity type is currently being compiled we use this
-    // field to prevent infinite recursion.
-    entity_type: Option<QualifiedName<'a>>,
+    in_progress: Option<InProgress<'a>>,
     current: Compiled<'a>,
 }
 
@@ -39,7 +49,7 @@ impl<'a, 'stack> Stack<'a, 'stack> {
     pub fn new_frame(&'stack self) -> Self {
         Self {
             parent: Some(self),
-            entity_type: None,
+            in_progress: None,
             current: Compiled::default(),
         }
     }
@@ -48,15 +58,31 @@ impl<'a, 'stack> Stack<'a, 'stack> {
     /// navigation-property references.
     #[must_use]
     pub const fn with_entity_type(mut self, name: QualifiedName<'a>) -> Self {
-        self.entity_type = Some(name);
+        self.in_progress = Some(InProgress::Entity(name));
         self
+    }
+
+    /// Track the complex type being compiled to avoid cycles caused by
+    /// self-referential properties.
+    #[must_use]
+    pub const fn with_complex_type(mut self, name: QualifiedName<'a>) -> Self {
+        self.in_progress = Some(InProgress::Complex(name));
+        self
+    }
+
+    /// Check whether a complex type is currently being compiled in this
+    /// frame or any parent frame.
+    #[must_use]
+    pub fn compiling_complex_type(&self, qtype: QualifiedName<'a>) -> bool {
+        matches!(self.in_progress, Some(InProgress::Complex(v)) if v == qtype)
+            || self.parent.is_some_and(|p| p.compiling_complex_type(qtype))
     }
 
     /// Check that entity this has been compiled or is being compiled.
     #[must_use]
     pub fn contains_entity(&self, qtype: QualifiedName<'a>) -> bool {
         self.current.entity_types.contains_key(&qtype)
-            || self.entity_type.is_some_and(|v| v == qtype)
+            || matches!(self.in_progress, Some(InProgress::Entity(v)) if v == qtype)
             || self.parent.is_some_and(|p| p.contains_entity(qtype))
     }
 
@@ -91,7 +117,7 @@ impl<'a, 'stack> Stack<'a, 'stack> {
     pub fn merge(self, c: Compiled<'a>) -> Self {
         Self {
             parent: self.parent,
-            entity_type: self.entity_type,
+            in_progress: self.in_progress,
             current: self.current.merge(c),
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.90.0"
 profile = "minimal"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
schema 2026.1 introduced new self-referencial complex type use case `MapFrom` - https://redfish.dmtf.org/schemas/v1/AttributeRegistry_v1.xml

This breaks compiler and makes it self-referential. 

Fix introduces different handling of such complex types.