### PR TITLE
feat(quirks): add Dell PowerEdge XE9780 platform class

### DIFF
--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -143,6 +143,7 @@ serde_json = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
 tagged-types = { workspace = true }
+uuid = {workspace = true}
 
 [build-dependencies]
 nv-redfish-csdl-compiler = { workspace = true }

--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use nv_redfish_core::Bmc;
+
 use crate::schema::service_root::ServiceRoot;
+use crate::Error;
 
 #[cfg(feature = "accounts")]
 use crate::account::SlotDefinedConfig as SlotDefinedUserAccountsConfig;
@@ -27,10 +30,11 @@ pub struct BmcQuirks {
 
 // Platform shouldn't be considered as vendor. Actually it is class of
 // devices that have the same set of quirks.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 enum Platform {
     Hpe,
     Dell,
+    DellPEXE9780,
     AmiViking,
     AmiGb300,
     VeraRubin,
@@ -42,8 +46,9 @@ enum Platform {
 }
 
 impl BmcQuirks {
-    pub fn new(root: &ServiceRoot) -> Self {
+    pub async fn new<B: Bmc>(root: &ServiceRoot, bmc: &B) -> Result<Self, Error<B>> {
         let vendor_str = root.vendor.as_ref().and_then(Option::as_deref);
+
         let redfish_version_str = root.redfish_version.as_deref();
         let product_str = root.product.as_ref().and_then(Option::as_deref);
         // The GB300 host BMC exposes an AMI OEM `RtpVersion` in the service
@@ -59,6 +64,9 @@ impl BmcQuirks {
             .and_then(|v| v.as_str());
         let platform = match vendor_str {
             Some("HPE") => Some(Platform::Hpe),
+            Some("Dell") if Self::check_if_dell_pe_x9780(root, bmc).await? => {
+                Some(Platform::DellPEXE9780)
+            }
             Some("Dell") => Some(Platform::Dell),
             Some("AMI") if redfish_version_str == Some("1.11.0") => Some(Platform::AmiViking),
             Some("AMI") if rtp_version == Some("13.09.1") => Some(Platform::AmiGb300),
@@ -75,7 +83,38 @@ impl BmcQuirks {
             None if redfish_version_str == Some("1.9.0") => Some(Platform::Anonymous1_9_0),
             _ => None,
         };
-        Self { platform }
+        Ok(Self { platform })
+    }
+
+    #[cfg(feature = "computer-systems")]
+    async fn check_if_dell_pe_x9780<B: Bmc>(root: &ServiceRoot, bmc: &B) -> Result<bool, Error<B>> {
+        if let Some(systems) = &root.systems {
+            if let Ok(systems) = systems.get(bmc).await {
+                for member in &systems.members {
+                    if let Ok(cs) = member.get(bmc).await {
+                        if cs
+                            .model
+                            .clone()
+                            .unwrap_or_else(|| Some(String::new()))
+                            .unwrap_or_else(String::new)
+                            .to_ascii_lowercase()
+                            .contains("xe9780")
+                        {
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    #[cfg(not(feature = "computer-systems"))]
+    async fn check_if_dell_pe_x9780<B: Bmc>(
+        _root: &ServiceRoot,
+        _bmc: &B,
+    ) -> Result<bool, Error<B>> {
+        Err(Error::MissingFeature("computer-systems".into()))
     }
 
     // Account type is required according to schema specification
@@ -95,11 +134,13 @@ impl BmcQuirks {
     #[cfg(feature = "accounts")]
     pub(crate) fn slot_defined_user_accounts(&self) -> Option<SlotDefinedUserAccountsConfig> {
         self.platform.as_ref().and_then(|platform| {
-            (platform == &Platform::Dell).then_some(SlotDefinedUserAccountsConfig {
-                min_slot: Some(3),
-                hide_disabled: true,
-                disable_account_on_delete: true,
-            })
+            (platform == &Platform::Dell || platform == &Platform::DellPEXE9780).then_some(
+                SlotDefinedUserAccountsConfig {
+                    min_slot: Some(3),
+                    hide_disabled: true,
+                    disable_account_on_delete: true,
+                },
+            )
         })
     }
 
@@ -108,7 +149,7 @@ impl BmcQuirks {
     // SoftwareInventoryCollection).
     #[cfg(feature = "update-service")]
     pub(crate) fn fw_inventory_wrong_release_date(&self) -> bool {
-        self.platform == Some(Platform::Dell)
+        self.platform == Some(Platform::Dell) || self.platform == (Some(Platform::DellPEXE9780))
     }
 
     /// In some cases there is addtional fields in Links.ContainedBy in
@@ -180,7 +221,7 @@ impl BmcQuirks {
     /// this is invalid Edm.DateTimeOffset.
     #[cfg(feature = "computer-systems")]
     pub(crate) fn computer_systems_wrong_last_reset_time(&self) -> bool {
-        self.platform == Some(Platform::Dell)
+        self.platform == Some(Platform::Dell) || self.platform == (Some(Platform::DellPEXE9780))
     }
 
     /// In some implementations, Event records in SSE payload do not include
@@ -194,7 +235,7 @@ impl BmcQuirks {
     /// timezone offsets in `EventTimestamp` (for example, `-0600`).
     #[cfg(feature = "event-service")]
     pub(crate) fn event_service_sse_wrong_timestamp_offset(&self) -> bool {
-        self.platform == Some(Platform::Dell)
+        self.platform == Some(Platform::Dell) || self.platform == (Some(Platform::DellPEXE9780))
     }
 
     /// In some implementations, Event records in SSE payload omit `EventType`.
@@ -253,7 +294,13 @@ impl BmcQuirks {
     pub(crate) const fn expand_is_not_working_properly(&self) -> bool {
         matches!(
             self.platform,
-            Some(Platform::AmiViking | Platform::AmiGb300)
+            Some(Platform::AmiViking | Platform::AmiGb300 | Platform::DellPEXE9780)
         )
+    }
+
+    /// In PE XE9780 some UUID type fields contain non-UUID formatted strings
+    #[cfg(feature = "chassis")]
+    pub(crate) fn chassis_contains_arbitrary_string_in_uuid_fields(&self) -> bool {
+        self.platform == Some(Platform::DellPEXE9780)
     }
 }

--- a/redfish/src/chassis/item.rs
+++ b/redfish/src/chassis/item.rs
@@ -102,6 +102,9 @@ impl Config {
         if quirks.bug_empty_uuid_field() {
             patches.push(normalize_empty_uuid_field);
         }
+        if quirks.chassis_contains_arbitrary_string_in_uuid_fields() {
+            patches.push(arbitary_string_uuid_field);
+        }
         let read_patch_fn = (!patches.is_empty())
             .then(|| Arc::new(move |v| patches.iter().fold(v, |acc, f| f(acc))) as ReadPatchFn);
         Self { read_patch_fn }
@@ -531,6 +534,20 @@ fn normalize_empty_uuid_field(mut v: JsonValue) -> JsonValue {
             let is_empty = uuid.as_str().is_some_and(str::is_empty);
             if is_empty {
                 *uuid = JsonValue::Null;
+            }
+        }
+    }
+    v
+}
+
+fn arbitary_string_uuid_field(mut v: JsonValue) -> JsonValue {
+    if let JsonValue::Object(ref mut obj) = v {
+        if let Some(id) = obj.get_mut("UUID") {
+            let is_wrong_format = id
+                .as_str()
+                .is_some_and(|ids| uuid::Uuid::parse_str(ids).is_err());
+            if is_wrong_format {
+                *id = JsonValue::Null;
             }
         }
     }

--- a/redfish/src/error.rs
+++ b/redfish/src/error.rs
@@ -59,6 +59,8 @@ pub enum Error<B: Bmc> {
     MetricReportDefinitionsNotAvailable,
     /// JSON parse error.
     Json(JsonError),
+    /// Missing feature error
+    MissingFeature(String),
 }
 
 impl<B: Bmc> Display for Error<B> {
@@ -105,6 +107,9 @@ impl<B: Bmc> Display for Error<B> {
             #[cfg(feature = "telemetry-service")]
             Self::MetricReportDefinitionsNotAvailable => {
                 write!(f, "Metric report definitions are not available")
+            },
+            Self::MissingFeature(feature) => {
+                write!(f, "Missing feature {feature}")
             }
         }
     }

--- a/redfish/src/service_root.rs
+++ b/redfish/src/service_root.rs
@@ -112,7 +112,7 @@ impl<B: Bmc> ServiceRoot<B> {
             .get(bmc.as_ref())
             .await
             .map_err(Error::Bmc)?;
-        let quirks = BmcQuirks::new(&root);
+        let quirks = BmcQuirks::new(&root, bmc.as_ref()).await?;
         let mut protocol_features = root
             .protocol_features_supported
             .as_ref()

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -59,6 +59,7 @@ serde_json = { workspace = true }
 futures-util = { workspace = true, features = ["io"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 trybuild = { workspace = true }
+uuid = {workspace = true}
 
 [build-dependencies]
 nv-redfish-csdl-compiler = { workspace = true }

--- a/tests/tests/test-dell-pe-xe9780.rs
+++ b/tests/tests/test-dell-pe-xe9780.rs
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 MIRANTIS, INC. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use nv_redfish::ServiceRoot;
+use nv_redfish_core::ODataId;
+use nv_redfish_tests::{Bmc, Expect, ODATA_ID, ODATA_TYPE};
+use serde_json::json;
+use std::{error::Error as StdError, str::FromStr, sync::Arc};
+use tokio::test;
+use uuid::Uuid;
+
+const SERVICE_ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_15_0.ServiceRoot";
+
+#[test]
+async fn pe_xe9780_wrong_uuid_field() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let root_id = ODataId::service_root();
+    let _ = expect_dell_pe_xe9780_service_root(bmc.clone())?;
+    let _ = expect_dell_pe_xe9780_systems_collection(bmc.clone())?;
+    let root = ServiceRoot::new(bmc.clone()).await?;
+    let chassis_odata_id = format!("{}/Chassis", root_id);
+    let chassis_first = format!("{}/Chassis_1", chassis_odata_id);
+    let chassis_second = format!("{}/Chassis_2", chassis_odata_id);
+
+    let chassis_collection_json = json!({
+         ODATA_ID: chassis_odata_id,
+         ODATA_TYPE: "#ChassisCollection.ChassisCollection",
+         "Description": "Collection of Chassis",
+          "Members": [
+            {
+              ODATA_ID: chassis_first
+            },
+            {
+              ODATA_ID: chassis_second
+            }
+          ],
+          "Members@odata.count": 2,
+          "Name": "Chassis Collection"
+    });
+    let chassis_first_json_buggy = json!({
+         ODATA_ID: chassis_first,
+         ODATA_TYPE: "#Chassis.v1_22_0.Chassis",
+         "Id": "Chassis_1",
+         "Name": "Chassis_1",
+         "ChassisType": "Component",
+         "UUID": "just_a_string"
+    });
+    let chassis_second_json = json!({
+         ODATA_ID: chassis_second,
+         ODATA_TYPE: "#Chassis.v1_22_0.Chassis",
+         "Id": "Chassis_2",
+         "Name": "Chassis_2",
+         "ChassisType": "Component",
+         "UUID": "ec710fec-e8e4-497e-819e-8c66fb5ffb91"
+    });
+
+    bmc.expect(Expect::get(chassis_odata_id, chassis_collection_json));
+    bmc.expect(Expect::get(chassis_first, chassis_first_json_buggy));
+    bmc.expect(Expect::get(chassis_second, chassis_second_json));
+
+    let chassis_collection = root.chassis().await?.unwrap();
+    let members = chassis_collection.members().await?;
+
+    assert!(members[0].raw().uuid.unwrap().is_none());
+    assert_eq!(
+        members[1].raw().uuid.unwrap().unwrap(),
+        Uuid::from_str("ec710fec-e8e4-497e-819e-8c66fb5ffb91").unwrap()
+    );
+
+    Ok(())
+}
+
+fn expect_dell_pe_xe9780_service_root(bmc: Arc<Bmc>) -> Result<(), Box<dyn StdError>> {
+    let root_id = ODataId::service_root();
+    let root_json = json!({
+      ODATA_ID: &root_id,
+      ODATA_TYPE: SERVICE_ROOT_DATA_TYPE,
+      "Id": "RootService",
+      "Name": "Root Service",
+      "Vendor": "Dell",
+      "Product": "Integrated Dell Remote Access Controller",
+      "Links": {
+          "Sessions": {
+              ODATA_ID: format!("{}/SessionService/Sessions", &root_id),
+          }
+       },
+      "Chassis": {
+        ODATA_ID: format!("{}/Chassis", &root_id),
+      },
+      "Systems": {
+        ODATA_ID: format!("{}/Systems", &root_id),
+      },
+    });
+    bmc.expect(Expect::get(&root_id, &root_json));
+    Ok(())
+}
+
+fn expect_dell_pe_xe9780_systems_collection(bmc: Arc<Bmc>) -> Result<(), Box<dyn StdError>> {
+    let root_id = ODataId::service_root();
+    let sys_odata_id = format!("{}/Systems", root_id);
+    let hgx_odata_id = format!("{}/HGX_Baseboard_0", &sys_odata_id);
+    let embedded_system_odata_id = format!("{}/System.Embedded.1", &sys_odata_id);
+    let systems_json = json!({
+          ODATA_ID: sys_odata_id,
+          ODATA_TYPE: "#ComputerSystemCollection.ComputerSystemCollection",
+          "Description": "Collection of Computer Systems",
+          "Members": [
+            {
+              ODATA_ID: hgx_odata_id
+            },
+            {
+              ODATA_ID: embedded_system_odata_id
+            }
+          ],
+          "Members@odata.count": 2,
+          "Name": "Computer System Collection"
+    });
+
+    let hgx_json = json!(
+        {
+          ODATA_ID: hgx_odata_id,
+          ODATA_TYPE: "#ComputerSystem.v1_22_0.ComputerSystem",
+          "Description": "Computer System",
+          "Name": "HGX_Baseboard_0",
+          "Id": "HGX_Baseboard_0",
+          "Model": "NA"
+        }
+    );
+
+    let embedded_system_json = json!(
+        {
+          ODATA_ID: embedded_system_odata_id,
+          ODATA_TYPE: "#ComputerSystem.v1_25_0.ComputerSystem",
+          "Description": "Computer System",
+          "Name": "System",
+          "Id": "System.Embedded.1",
+          "Model": "PowerEdge XE9780",
+        }
+    );
+
+    bmc.expect(Expect::get(&sys_odata_id, &systems_json));
+    bmc.expect(Expect::get(&hgx_odata_id, &hgx_json));
+    bmc.expect(Expect::get(
+        &embedded_system_odata_id,
+        &embedded_system_json,
+    ));
+
+    Ok(())
+}


### PR DESCRIPTION
The iDRAC service root reports only Vendor: "Dell", which the XE9780 shares with every other PowerEdge, so it cannot be told apart from the root payload alone. Classification now walks the computer system collection and looks for a member whose Model contains xe9780. The new platform inherits the existing Dell quirks and adds two of its own:
- $expand responses are incomplete, so collections are fetched with plain GETs and members individually.
- chassis UUID may carry an arbitrary string rather than a GUID; a read patch replaces such values with null so the resource still deserializes.
relates to: [NICO ticket](https://github.com/NVIDIA/infra-controller/issues/3227)