### PR TITLE
feat(redfish)!: serialize generated resource models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ std-not-standalone-features = assembly \
 
 std-standalone-features = $(filter-out $(std-not-standalone-features),$(all-std-features))
 
-ci-features-list := $(subst $(space),$(comma),$(all-std-features)),http-extras
+ci-features-list := $(subst $(space),$(comma),$(all-std-features)),http-extras,resource-serialization
 
 # Feature sets whose only job is to prove the configuration type checks.
 # Nothing downstream consumes the artifacts, so they run under `cargo check`:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Common feature groups:
 
 - `bmc-http`: re-export `nv-redfish-bmc-http` from `nv_redfish::bmc_http`.
 - `http-extras`: enable optional HTTP client capabilities, including per-BMC operation concurrency limits; implies `bmc-http`.
+- `resource-serialization`: enable Serde serialization for generated read and
+  excerpt models.
 - `std-redfish`: enable a broad standard Redfish surface.
 - Service features: `accounts`, `assembly`, `bios`, `boot-options`,
   `chassis`, `computer-systems`, `ethernet-interfaces`, `event-service`,

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -22,9 +22,9 @@
 //! - `T`: request parameters payload type (sent as the POST body when running the action)
 //! - `R`: response type returned by the BMC for that action
 //!
-//! Only the `target` field is deserialized. Any additional metadata
-//! (such as `...@Redfish.AllowableValues`) is ignored by this type
-//! and may be used by higher layers.
+//! Only the `target` field is retained when serializing or deserializing.
+//! Additional metadata (such as `...@Redfish.AllowableValues`) is ignored by
+//! this type and may be used by higher layers.
 //!
 //! Example: how an action appears in a Redfish resource and which part maps to [`Action`]
 //!
@@ -44,24 +44,26 @@
 //! ```
 //!
 //! The [`Action<T, R>`] value corresponds to the inner object of
-//! `"#ComputerSystem.Reset"` and deserializes the `target` field only.
+//! `"#ComputerSystem.Reset"` and retains the `target` field only.
 //!
 
-use crate::Bmc;
-use crate::ModificationResponse;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
+use std::marker::PhantomData;
+
+use crate::Bmc;
+use crate::ModificationResponse;
+
 use serde::Deserialize;
 use serde::Serialize;
-use std::marker::PhantomData;
 
 /// URI reference for the `target` field of an action.
 ///
 /// The [`Bmc`] implementation resolves this value when the action is run and
 /// may reject values that violate its outbound request policy before transport.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct ActionTarget(String);
 
@@ -85,22 +87,23 @@ impl Display for ActionTarget {
     }
 }
 
-/// Defines a deserializable Action. It is almost always a member of the
-/// `Actions` struct in different parts of the Redfish object tree.
+/// Defines a serializable and deserializable Action. It is almost always a
+/// member of the `Actions` struct in different parts of the Redfish object tree.
 ///
 /// `T` is the type for parameters.
 /// `R` is the type for the return value.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Action<T, R> {
     /// URI reference used to trigger the action.
     #[serde(rename = "target")]
     pub target: ActionTarget,
     // TODO: we can retrieve constraints on attributes here.
     /// Establishes a dependency on the `T` (parameters) type.
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     _marker: PhantomData<T>,
+
     /// Establishes a dependency on the `R` (return value) type.
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     _marker_retval: PhantomData<R>,
 }
 
@@ -157,6 +160,22 @@ mod tests {
         assert_eq!(
             format!("{action:?}"),
             "Action { target: ActionTarget(\"/redfish/v1/Actions/Test\") }"
+        );
+    }
+
+    #[test]
+    fn serialization_includes_only_the_action_target() {
+        let action: Action<NotDebug, NotDebug> = Action {
+            target: ActionTarget::new("/redfish/v1/Actions/Test".into()),
+            _marker: PhantomData,
+            _marker_retval: PhantomData,
+        };
+
+        let value = serde_json::to_value(action).expect("action must serialize");
+
+        assert_eq!(
+            value,
+            serde_json::json!({"target": "/redfish/v1/Actions/Test"})
         );
     }
 }

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -47,17 +47,15 @@
 //! `"#ComputerSystem.Reset"` and retains the `target` field only.
 //!
 
+use crate::Bmc;
+use crate::ModificationResponse;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
-use std::marker::PhantomData;
-
-use crate::Bmc;
-use crate::ModificationResponse;
-
 use serde::Deserialize;
 use serde::Serialize;
+use std::marker::PhantomData;
 
 /// URI reference for the `target` field of an action.
 ///
@@ -101,7 +99,6 @@ pub struct Action<T, R> {
     /// Establishes a dependency on the `T` (parameters) type.
     #[serde(skip)]
     _marker: PhantomData<T>,
-
     /// Establishes a dependency on the `R` (return value) type.
     #[serde(skip)]
     _marker_retval: PhantomData<R>,

--- a/core/src/nav_property.rs
+++ b/core/src/nav_property.rs
@@ -27,14 +27,11 @@
 //! - [`NavProperty<T>::id`] is always available (delegates to inner entity for expanded form).
 //! - [`NavProperty<T>::get`] returns `Arc<T>`; if already expanded, it clones the `Arc` without I/O.
 //! - [`EntityTypeRef::etag`] is `None` for reference form.
-//! - Serialization preserves the reference or expanded representation held by the value.
 //!
 //! References:
 //! - DMTF Redfish Specification DSP0266 — `https://www.dmtf.org/standards/redfish`
 //! - OASIS OData 4.01 — navigation properties in CSDL
 //!
-
-use std::sync::Arc;
 
 use crate::Bmc;
 use crate::Creatable;
@@ -45,12 +42,12 @@ use crate::FilterQuery;
 use crate::ODataETag;
 use crate::ODataId;
 use crate::Updatable;
-
 use serde::de;
 use serde::de::Deserializer;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::Serializer;
+use std::sync::Arc;
 
 /// Reference variant of the navigation property (only `@odata.id`
 /// property is specified).

--- a/core/src/nav_property.rs
+++ b/core/src/nav_property.rs
@@ -27,11 +27,14 @@
 //! - [`NavProperty<T>::id`] is always available (delegates to inner entity for expanded form).
 //! - [`NavProperty<T>::get`] returns `Arc<T>`; if already expanded, it clones the `Arc` without I/O.
 //! - [`EntityTypeRef::etag`] is `None` for reference form.
+//! - Serialization preserves the reference or expanded representation held by the value.
 //!
 //! References:
 //! - DMTF Redfish Specification DSP0266 — `https://www.dmtf.org/standards/redfish`
 //! - OASIS OData 4.01 — navigation properties in CSDL
 //!
+
+use std::sync::Arc;
 
 use crate::Bmc;
 use crate::Creatable;
@@ -42,11 +45,12 @@ use crate::FilterQuery;
 use crate::ODataETag;
 use crate::ODataId;
 use crate::Updatable;
+
 use serde::de;
 use serde::de::Deserializer;
 use serde::Deserialize;
 use serde::Serialize;
-use std::sync::Arc;
+use serde::Serializer;
 
 /// Reference variant of the navigation property (only `@odata.id`
 /// property is specified).
@@ -146,6 +150,21 @@ where
     }
 }
 
+impl<T> Serialize for NavProperty<T>
+where
+    T: EntityTypeRef + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Expanded(expanded) => expanded.0.as_ref().serialize(serializer),
+            Self::Reference(reference) => reference.serialize(serializer),
+        }
+    }
+}
+
 impl<T: EntityTypeRef> EntityTypeRef for NavProperty<T> {
     fn odata_id(&self) -> &ODataId {
         match self {
@@ -241,8 +260,9 @@ mod tests {
     use crate::ODataETag;
     use crate::ODataId;
     use serde::Deserialize;
+    use serde::Serialize;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Serialize)]
     struct DummyEntity {
         #[serde(rename = "@odata.id")]
         odata_id: ODataId,
@@ -306,6 +326,13 @@ mod tests {
         let parsed: NavProperty<DummyEntity> =
             serde_json::from_str(r#"{ "@odata.id": "/redfish/v1/Systems/System_1" }"#).unwrap();
 
+        let serialized = serde_json::to_value(&parsed).expect("reference must serialize");
+
+        assert_eq!(
+            serialized,
+            serde_json::json!({"@odata.id": "/redfish/v1/Systems/System_1"})
+        );
+
         match parsed {
             NavProperty::Reference(reference) => {
                 assert_eq!(
@@ -326,6 +353,16 @@ mod tests {
             }"#,
         )
         .unwrap();
+
+        let serialized = serde_json::to_value(&parsed).expect("expanded property must serialize");
+
+        assert_eq!(
+            serialized,
+            serde_json::json!({
+                "@odata.id": "/redfish/v1/Systems/System_1",
+                "Name": "System_1"
+            })
+        );
 
         match parsed {
             NavProperty::Expanded(expanded) => {

--- a/csdl-compiler/src/commands.rs
+++ b/csdl-compiler/src/commands.rs
@@ -132,6 +132,24 @@ pub enum Commands {
 ///
 /// Returns an error if command processing fails.
 pub fn process_command(command: &Commands) -> Result<Vec<String>, Error> {
+    process_command_inner(command, false)
+}
+
+/// Process a compiler command with serialization enabled for read and excerpt models.
+///
+/// # Errors
+///
+/// Returns an error if command processing fails.
+pub fn process_command_with_read_model_serialization(
+    command: &Commands,
+) -> Result<Vec<String>, Error> {
+    process_command_inner(command, true)
+}
+
+fn process_command_inner(
+    command: &Commands,
+    serialize_read_models: bool,
+) -> Result<Vec<String>, Error> {
     let mut display_output = Vec::new();
     match command {
         Commands::Compile {
@@ -161,7 +179,8 @@ pub fn process_command(command: &Commands) -> Result<Vec<String>, Error> {
                 .map_err(Error::compile_error)?;
             let compiled = optimize(compiled, &OptimizerConfig::default());
             let generator = RustGenerator::new(compiled, GeneratorConfig::default())
-                .map_err(Error::generate_error)?;
+                .map_err(Error::generate_error)?
+                .with_read_model_serialization(serialize_read_models);
 
             let syntax_tree =
                 syn::parse2::<syn::File>(generator.generate()).map_err(Error::ParseGenerated)?;
@@ -191,7 +210,8 @@ pub fn process_command(command: &Commands) -> Result<Vec<String>, Error> {
                 .map_err(Error::compile_error)?;
             let compiled = optimize(compiled, &OptimizerConfig::default());
             let generator = RustGenerator::new(compiled, GeneratorConfig::default())
-                .map_err(Error::generate_error)?;
+                .map_err(Error::generate_error)?
+                .with_read_model_serialization(serialize_read_models);
             let syntax_tree =
                 syn::parse2::<syn::File>(generator.generate()).map_err(Error::ParseGenerated)?;
             write(output, prettyplease::unparse(&syntax_tree))

--- a/csdl-compiler/src/commands.rs
+++ b/csdl-compiler/src/commands.rs
@@ -178,9 +178,14 @@ fn process_command_inner(
                 )
                 .map_err(Error::compile_error)?;
             let compiled = optimize(compiled, &OptimizerConfig::default());
-            let generator = RustGenerator::new(compiled, GeneratorConfig::default())
-                .map_err(Error::generate_error)?
-                .with_read_model_serialization(serialize_read_models);
+            let generator = RustGenerator::new(
+                compiled,
+                GeneratorConfig {
+                    serialize_read_models,
+                    ..GeneratorConfig::default()
+                },
+            )
+            .map_err(Error::generate_error)?;
 
             let syntax_tree =
                 syn::parse2::<syn::File>(generator.generate()).map_err(Error::ParseGenerated)?;
@@ -209,9 +214,14 @@ fn process_command_inner(
                 })
                 .map_err(Error::compile_error)?;
             let compiled = optimize(compiled, &OptimizerConfig::default());
-            let generator = RustGenerator::new(compiled, GeneratorConfig::default())
-                .map_err(Error::generate_error)?
-                .with_read_model_serialization(serialize_read_models);
+            let generator = RustGenerator::new(
+                compiled,
+                GeneratorConfig {
+                    serialize_read_models,
+                    ..GeneratorConfig::default()
+                },
+            )
+            .map_err(Error::generate_error)?;
             let syntax_tree =
                 syn::parse2::<syn::File>(generator.generate()).map_err(Error::ParseGenerated)?;
             write(output, prettyplease::unparse(&syntax_tree))

--- a/csdl-compiler/src/generator/rust/config.rs
+++ b/csdl-compiler/src/generator/rust/config.rs
@@ -29,6 +29,9 @@ pub struct Config {
     /// Maximum number of parameters that are passed as function
     /// parameter before switching to action struct.
     pub action_fn_max_param_number_threshold: usize,
+
+    /// Whether generated read and excerpt models implement `serde::Serialize`.
+    pub serialize_read_models: bool,
 }
 
 impl Default for Config {
@@ -39,6 +42,7 @@ impl Default for Config {
                 "Base".parse().expect("should always be parsed"),
             ),
             action_fn_max_param_number_threshold: 3,
+            serialize_read_models: false,
         }
     }
 }

--- a/csdl-compiler/src/generator/rust/enum_def.rs
+++ b/csdl-compiler/src/generator/rust/enum_def.rs
@@ -62,9 +62,8 @@ impl EnumDef<'_> {
                 Self::#member_name => #snake_case_literal,
             });
         }
-
         members_content.extend(quote! {
-            #[doc = " Fallback value for values that are not supported by the current Redfish schema."]
+            #[doc = " Fallback value for values that are not supported by current version of Redfish schema."]
             #[doc = " The original wire spelling is not retained; serialization emits `UnsupportedValue`."]
             #[serde(other)]
             UnsupportedValue,

--- a/csdl-compiler/src/generator/rust/enum_def.rs
+++ b/csdl-compiler/src/generator/rust/enum_def.rs
@@ -62,8 +62,10 @@ impl EnumDef<'_> {
                 Self::#member_name => #snake_case_literal,
             });
         }
+
         members_content.extend(quote! {
-            #[doc = " Fallback value for values that are not supported by current version of Redfish schema."]
+            #[doc = " Fallback value for values that are not supported by the current Redfish schema."]
+            #[doc = " The original wire spelling is not retained; serialization emits `UnsupportedValue`."]
             #[serde(other)]
             UnsupportedValue,
         });

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -122,6 +122,7 @@ impl Display for Error<'_> {
 pub struct RustGenerator<'a> {
     root: ModDef<'a>,
     config: Config,
+    serialize_read_models: bool,
 }
 
 impl<'a> RustGenerator<'a> {
@@ -168,7 +169,22 @@ impl<'a> RustGenerator<'a> {
             .enum_types
             .into_iter()
             .try_fold(root, |m, (_, t)| m.add_enum_type(t))?;
-        Ok(Self { root, config })
+
+        Ok(Self {
+            root,
+            config,
+            serialize_read_models: false,
+        })
+    }
+
+    /// Configures whether generated read and excerpt models implement
+    /// [`serde::Serialize`].
+    ///
+    /// Serialization is disabled by default.
+    #[must_use]
+    pub const fn with_read_model_serialization(mut self, enabled: bool) -> Self {
+        self.serialize_read_models = enabled;
+        self
     }
 
     /// Generate Rust code from the collected data.
@@ -227,7 +243,69 @@ impl<'a> RustGenerator<'a> {
                 pub type PrimitiveType = nv_redfish_core::EdmPrimitiveType;
             }
         });
-        self.root.generate(&mut tokens, &self.config);
+
+        self.root.generate_with_read_model_serialization(
+            &mut tokens,
+            &self.config,
+            self.serialize_read_models,
+        );
+
         tokens
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+    use super::RustGenerator;
+    use crate::compiler::Config as CompilerConfig;
+    use crate::compiler::SchemaBundle;
+    use crate::edmx::Edmx;
+    use quote::quote;
+
+    #[test]
+    fn read_model_serialization_is_selected_per_generator_invocation() -> Result<(), String> {
+        let schema = r#"<edmx:Edmx Version="4.0">
+          <edmx:DataServices>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Example">
+              <EntityType Name="Example"/>
+            </Schema>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource">
+              <EntityType Name="Resource" Abstract="true"/>
+              <EntityType Name="ResourceCollection" Abstract="true"/>
+            </Schema>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings">
+              <ComplexType Name="Settings"/><ComplexType Name="PreferredApplyTime"/>
+            </Schema>
+          </edmx:DataServices>
+        </edmx:Edmx>"#;
+
+        let bundle = SchemaBundle {
+            edmx_docs: vec![Edmx::parse(schema).map_err(|error| error.to_string())?],
+            root_set_threshold: None,
+        };
+
+        let serialize_and_deserialize = quote! {
+            #[derive(Serialize)]
+            #[derive(Deserialize, Debug)]
+            pub struct Example
+        }
+        .to_string();
+
+        for enabled in [false, true] {
+            let compiled = bundle
+                .compile_all(CompilerConfig::default())
+                .map_err(|error| error.to_string())?;
+
+            let generated = RustGenerator::new(compiled, Config::default())
+                .map_err(|error| error.to_string())?
+                .with_read_model_serialization(enabled)
+                .generate()
+                .to_string();
+
+            assert_eq!(generated.contains(&serialize_and_deserialize), enabled);
+        }
+
+        Ok(())
     }
 }

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -122,7 +122,6 @@ impl Display for Error<'_> {
 pub struct RustGenerator<'a> {
     root: ModDef<'a>,
     config: Config,
-    serialize_read_models: bool,
 }
 
 impl<'a> RustGenerator<'a> {
@@ -169,22 +168,7 @@ impl<'a> RustGenerator<'a> {
             .enum_types
             .into_iter()
             .try_fold(root, |m, (_, t)| m.add_enum_type(t))?;
-
-        Ok(Self {
-            root,
-            config,
-            serialize_read_models: false,
-        })
-    }
-
-    /// Configures whether generated read and excerpt models implement
-    /// [`serde::Serialize`].
-    ///
-    /// Serialization is disabled by default.
-    #[must_use]
-    pub const fn with_read_model_serialization(mut self, enabled: bool) -> Self {
-        self.serialize_read_models = enabled;
-        self
+        Ok(Self { root, config })
     }
 
     /// Generate Rust code from the collected data.
@@ -243,13 +227,7 @@ impl<'a> RustGenerator<'a> {
                 pub type PrimitiveType = nv_redfish_core::EdmPrimitiveType;
             }
         });
-
-        self.root.generate_with_read_model_serialization(
-            &mut tokens,
-            &self.config,
-            self.serialize_read_models,
-        );
-
+        self.root.generate(&mut tokens, &self.config);
         tokens
     }
 }
@@ -297,9 +275,12 @@ mod tests {
                 .compile_all(CompilerConfig::default())
                 .map_err(|error| error.to_string())?;
 
-            let generated = RustGenerator::new(compiled, Config::default())
+            let config = Config {
+                serialize_read_models: enabled,
+                ..Config::default()
+            };
+            let generated = RustGenerator::new(compiled, config)
                 .map_err(|error| error.to_string())?
-                .with_read_model_serialization(enabled)
                 .generate()
                 .to_string();
 

--- a/csdl-compiler/src/generator/rust/mod_def.rs
+++ b/csdl-compiler/src/generator/rust/mod_def.rs
@@ -354,15 +354,6 @@ impl<'a> ModDef<'a> {
 
     /// Generate Rust code.
     pub fn generate(self, tokens: &mut TokenStream, config: &Config) {
-        self.generate_with_read_model_serialization(tokens, config, false);
-    }
-
-    pub(crate) fn generate_with_read_model_serialization(
-        self,
-        tokens: &mut TokenStream,
-        config: &Config,
-        serialize_read_models: bool,
-    ) {
         let mut typedefs = self.typedefs.into_values().collect::<Vec<_>>();
         typedefs.sort_by_key(|v| v.name);
 
@@ -385,11 +376,11 @@ impl<'a> ModDef<'a> {
             }
 
             for s in structs {
-                s.generate_with_read_model_serialization(ts, config, serialize_read_models);
+                s.generate(ts, config);
             }
 
             for m in sub_mods {
-                m.generate_with_read_model_serialization(ts, config, serialize_read_models);
+                m.generate(ts, config);
             }
         };
 

--- a/csdl-compiler/src/generator/rust/mod_def.rs
+++ b/csdl-compiler/src/generator/rust/mod_def.rs
@@ -354,6 +354,15 @@ impl<'a> ModDef<'a> {
 
     /// Generate Rust code.
     pub fn generate(self, tokens: &mut TokenStream, config: &Config) {
+        self.generate_with_read_model_serialization(tokens, config, false);
+    }
+
+    pub(crate) fn generate_with_read_model_serialization(
+        self,
+        tokens: &mut TokenStream,
+        config: &Config,
+        serialize_read_models: bool,
+    ) {
         let mut typedefs = self.typedefs.into_values().collect::<Vec<_>>();
         typedefs.sort_by_key(|v| v.name);
 
@@ -376,11 +385,11 @@ impl<'a> ModDef<'a> {
             }
 
             for s in structs {
-                s.generate(ts, config);
+                s.generate_with_read_model_serialization(ts, config, serialize_read_models);
             }
 
             for m in sub_mods {
-                m.generate(ts, config);
+                m.generate_with_read_model_serialization(ts, config, serialize_read_models);
             }
         };
 

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -108,36 +108,18 @@ impl<'a> StructDef<'a> {
 
     /// Generate rust code for the structure.
     pub fn generate(self, tokens: &mut TokenStream, config: &Config) {
-        self.generate_with_read_model_serialization(tokens, config, false);
-    }
-
-    pub(crate) fn generate_with_read_model_serialization(
-        self,
-        tokens: &mut TokenStream,
-        config: &Config,
-        serialize_read_models: bool,
-    ) {
         for t in &self.generate {
             match t {
                 GenerateType::Create => self.generate_create(tokens, config),
-                GenerateType::Read => {
-                    self.generate_read(tokens, config, serialize_read_models);
-                }
-                GenerateType::Excerpt(v) => {
-                    self.generate_excerpt(tokens, config, v, serialize_read_models);
-                }
+                GenerateType::Read => self.generate_read(tokens, config),
+                GenerateType::Excerpt(v) => self.generate_excerpt(tokens, config, v),
                 GenerateType::Update => self.generate_update(tokens, config),
                 GenerateType::Action => self.generate_action(tokens, config),
             }
         }
     }
 
-    fn generate_read(
-        &self,
-        tokens: &mut TokenStream,
-        config: &Config,
-        serialize_read_models: bool,
-    ) {
+    fn generate_read(&self, tokens: &mut TokenStream, config: &Config) {
         let top = &config.top_module_alias;
         let mut content = TokenStream::new();
         let odata_id = Ident::new("odata_id", Span::call_site());
@@ -208,7 +190,9 @@ impl<'a> StructDef<'a> {
 
         let name = self.name;
 
-        let serialize = serialize_read_models.then(|| quote! { #[derive(Serialize)] });
+        let serialize = config
+            .serialize_read_models
+            .then(|| quote! { #[derive(Serialize)] });
 
         // Note: Manual implementation of Send and Sync is needed to
         // help compiler. It goes through all properties deeper and
@@ -276,7 +260,6 @@ impl<'a> StructDef<'a> {
         tokens: &mut TokenStream,
         config: &Config,
         excerpt_copy: &ExcerptCopy,
-        serialize_read_models: bool,
     ) {
         let mut content = TokenStream::new();
         let all_properties = self.properties.properties.iter().filter_map(|p| {
@@ -296,7 +279,9 @@ impl<'a> StructDef<'a> {
 
         let name = self.name.for_excerpt_copy(excerpt_copy);
 
-        let serialize = serialize_read_models.then(|| quote! { #[derive(Serialize)] });
+        let serialize = config
+            .serialize_read_models
+            .then(|| quote! { #[derive(Serialize)] });
 
         tokens.extend([quote! {
             #serialize
@@ -818,7 +803,6 @@ impl<'a> StructDef<'a> {
             }
             None => quote! { () },
         };
-
         quote! {
             #[serde(rename=#rename, skip_serializing_if = "Option::is_none")]
             pub #name: Option<#top::Action<#typename, #ret_type>>,

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -204,7 +204,7 @@ impl<'a> StructDef<'a> {
         tokens.extend([
             doc_format_and_generate(self.name, &self.odata),
             quote! {
-                #[derive(Deserialize, Debug)]
+                #[derive(Serialize, Deserialize, Debug)]
                 pub struct #name { #content }
                 #[doc = "SAFETY: All generated data types are Send"]
                 unsafe impl Send for #name {}
@@ -272,8 +272,9 @@ impl<'a> StructDef<'a> {
         content.extend(all_properties);
 
         let name = self.name.for_excerpt_copy(excerpt_copy);
+
         tokens.extend([quote! {
-            #[derive(Deserialize, Debug)]
+            #[derive(Serialize, Deserialize, Debug)]
             pub struct #name { #content }
         }]);
     }
@@ -304,12 +305,12 @@ impl<'a> StructDef<'a> {
                         quote! {
                             #[serde(rename="@odata.id")]
                             pub #odata_id: ODataId,
-                            #[serde(rename="@odata.etag")]
+                            #[serde(rename="@odata.etag", skip_serializing_if = "Option::is_none")]
                             pub #odata_etag: Option<ODataETag>,
                             #maybe_odata_type
-                            #[serde(rename = "@Redfish.Settings")]
+                            #[serde(rename = "@Redfish.Settings", skip_serializing_if = "Option::is_none")]
                             pub redfish_settings: Option<#top::settings::Settings>,
-                            #[serde(rename = "@Redfish.SettingsApplyTime")]
+                            #[serde(rename = "@Redfish.SettingsApplyTime", skip_serializing_if = "Option::is_none")]
                             pub redfish_settings_apply_type: Option<#top::settings::PreferredApplyTime>,
                         },
                         ImplType::Root,
@@ -573,9 +574,18 @@ impl<'a> StructDef<'a> {
         } else if required.into_inner() {
             quote! { #[serde(rename=#rename)] }
         } else if nullable.into_inner() {
-            quote! { #[serde(rename=#rename, default, deserialize_with="de_optional_nullable")] }
+            quote! {
+                #[serde(
+                    rename=#rename,
+                    default,
+                    deserialize_with="de_optional_nullable",
+                    skip_serializing_if = "Option::is_none"
+                )]
+            }
         } else {
-            quote! { #[serde(rename=#rename, default)] }
+            quote! {
+                #[serde(rename=#rename, default, skip_serializing_if = "Option::is_none")]
+            }
         }
     }
 
@@ -782,8 +792,9 @@ impl<'a> StructDef<'a> {
             }
             None => quote! { () },
         };
+
         quote! {
-            #[serde(rename=#rename)]
+            #[serde(rename=#rename, skip_serializing_if = "Option::is_none")]
             pub #name: Option<#top::Action<#typename, #ret_type>>,
         }
     }

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -108,18 +108,36 @@ impl<'a> StructDef<'a> {
 
     /// Generate rust code for the structure.
     pub fn generate(self, tokens: &mut TokenStream, config: &Config) {
+        self.generate_with_read_model_serialization(tokens, config, false);
+    }
+
+    pub(crate) fn generate_with_read_model_serialization(
+        self,
+        tokens: &mut TokenStream,
+        config: &Config,
+        serialize_read_models: bool,
+    ) {
         for t in &self.generate {
             match t {
                 GenerateType::Create => self.generate_create(tokens, config),
-                GenerateType::Read => self.generate_read(tokens, config),
-                GenerateType::Excerpt(v) => self.generate_excerpt(tokens, config, v),
+                GenerateType::Read => {
+                    self.generate_read(tokens, config, serialize_read_models);
+                }
+                GenerateType::Excerpt(v) => {
+                    self.generate_excerpt(tokens, config, v, serialize_read_models);
+                }
                 GenerateType::Update => self.generate_update(tokens, config),
                 GenerateType::Action => self.generate_action(tokens, config),
             }
         }
     }
 
-    fn generate_read(&self, tokens: &mut TokenStream, config: &Config) {
+    fn generate_read(
+        &self,
+        tokens: &mut TokenStream,
+        config: &Config,
+        serialize_read_models: bool,
+    ) {
         let top = &config.top_module_alias;
         let mut content = TokenStream::new();
         let odata_id = Ident::new("odata_id", Span::call_site());
@@ -189,6 +207,9 @@ impl<'a> StructDef<'a> {
         content.extend(all_properties);
 
         let name = self.name;
+
+        let serialize = serialize_read_models.then(|| quote! { #[derive(Serialize)] });
+
         // Note: Manual implementation of Send and Sync is needed to
         // help compiler. It goes through all properties deeper and
         // deepr in the Redfish tree until it hits the recursion
@@ -204,7 +225,8 @@ impl<'a> StructDef<'a> {
         tokens.extend([
             doc_format_and_generate(self.name, &self.odata),
             quote! {
-                #[derive(Serialize, Deserialize, Debug)]
+                #serialize
+                #[derive(Deserialize, Debug)]
                 pub struct #name { #content }
                 #[doc = "SAFETY: All generated data types are Send"]
                 unsafe impl Send for #name {}
@@ -254,6 +276,7 @@ impl<'a> StructDef<'a> {
         tokens: &mut TokenStream,
         config: &Config,
         excerpt_copy: &ExcerptCopy,
+        serialize_read_models: bool,
     ) {
         let mut content = TokenStream::new();
         let all_properties = self.properties.properties.iter().filter_map(|p| {
@@ -273,8 +296,11 @@ impl<'a> StructDef<'a> {
 
         let name = self.name.for_excerpt_copy(excerpt_copy);
 
+        let serialize = serialize_read_models.then(|| quote! { #[derive(Serialize)] });
+
         tokens.extend([quote! {
-            #[derive(Serialize, Deserialize, Debug)]
+            #serialize
+            #[derive(Deserialize, Debug)]
             pub struct #name { #content }
         }]);
     }

--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -27,6 +27,7 @@ http-extras = [
     "bmc-http",
     "nv-redfish-bmc-http/http-extras",
 ]
+resource-serialization = []
 
 std-redfish = [
     "accounts",

--- a/redfish/build.rs
+++ b/redfish/build.rs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nv_redfish_csdl_compiler::commands::process_command;
+use nv_redfish_csdl_compiler::commands::process_command as process_command_default;
+use nv_redfish_csdl_compiler::commands::process_command_with_read_model_serialization;
 use nv_redfish_csdl_compiler::commands::Commands;
 use nv_redfish_csdl_compiler::commands::DEFAULT_ROOT;
 use nv_redfish_csdl_compiler::features_manifest::FeaturesManifest;
@@ -41,6 +42,15 @@ fn run() -> Result<(), Box<dyn StdError>> {
     let features_manifest = PathBuf::from("features.toml");
     let manifest = FeaturesManifest::read(&features_manifest)?;
     rerun_for([&features_manifest]);
+
+    let serialize_read_models = cargo_feature_enabled("resource-serialization");
+
+    let process_command: fn(&Commands) -> Result<Vec<String>, nv_redfish_csdl_compiler::Error> =
+        if serialize_read_models {
+            process_command_with_read_model_serialization
+        } else {
+            process_command_default
+        };
 
     let redfish_csdl: [&str; 5] = [
         "Settings_v1.xml",

--- a/redfish/src/log_service/mod.rs
+++ b/redfish/src/log_service/mod.rs
@@ -153,3 +153,66 @@ impl<B: Bmc> Resource for LogService<B> {
         &self.data.as_ref().base
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::schema::log_entry::LogEntry;
+
+    #[test]
+    fn log_entry_serialization_preserves_retained_wire_properties() {
+        let value = serde_json::json!({
+            "@odata.id": "/redfish/v1/Systems/System/LogServices/EventLog/Entries/1",
+            "Id": "1",
+            "Name": "Event log entry",
+            "EntryType": "Event",
+            "MessageId": "ResourceEvent.1.0.ResourceErrorsDetected",
+            "DiagnosticDataType": "CPER",
+            "DiagnosticData": null,
+            "Actions": {},
+            "CPER": {
+                "NotificationType": null,
+                "Oem": {
+                    "Vendor": {
+                        "RecordType": "Example"
+                    }
+                }
+            },
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Systems/System"
+                }
+            },
+            "Oem": {
+                "Vendor": {
+                    "ErrorId": "EXAMPLE-ERROR"
+                }
+            }
+        });
+
+        let entry: LogEntry =
+            serde_json::from_value(value.clone()).expect("log entry must deserialize");
+
+        let serialized = serde_json::to_value(entry).expect("log entry must serialize");
+
+        assert_eq!(serialized, value);
+    }
+
+    #[test]
+    fn log_entry_serialization_normalizes_unknown_enum_values() {
+        let value = serde_json::json!({
+            "@odata.id": "/redfish/v1/Systems/System/LogServices/EventLog/Entries/1",
+            "Id": "1",
+            "Name": "Event log entry",
+            "EntryType": "FutureEntryType"
+        });
+
+        let entry: LogEntry = serde_json::from_value(value).expect("log entry must deserialize");
+
+        let serialized = serde_json::to_value(entry).expect("log entry must serialize");
+
+        assert_eq!(
+            serialized.get("EntryType"),
+            Some(&serde_json::json!("UnsupportedValue"))
+        );
+    }
+}

--- a/redfish/src/log_service/mod.rs
+++ b/redfish/src/log_service/mod.rs
@@ -154,7 +154,7 @@ impl<B: Bmc> Resource for LogService<B> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "resource-serialization"))]
 mod tests {
     use crate::schema::log_entry::LogEntry;
 


### PR DESCRIPTION
Add opt-in `serde` serialization for generated Redfish read and excerpt models and their supporting action and navigation types. Applications can serialize resources such as `LogEntry` for content fingerprinting, persistence, and other downstream use.

Enable generated model serialization with the `resource-serialization` feature.

### Breaking Changes

This is a source-breaking change for callers that construct `generator::rust::Config` with a struct literal.