### PR TITLE
fix(redfish): gate nullable members quirk with collection patches

### DIFF
--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -259,6 +259,7 @@ impl BmcQuirks {
 
     /// Some implementations return the `Members` field of
     /// a collection as `null` instead of an empty array (`[]`).
+    #[cfg(feature = "patch-collection")]
     pub(crate) fn bug_nullable_members(&self) -> bool {
         self.platform == Some(Platform::NvidiaDpu)
     }


### PR DESCRIPTION
The nullable collection-members quirk is only used by collection patching. Feature combinations without `patch-collection` compiled the quirk method without its caller, producing repeated dead-code warnings.