### PR TITLE
fix(workspace): resolve assertion formatting and rustdoc link warnings

### DIFF
--- a/csdl-compiler/src/query.rs
+++ b/csdl-compiler/src/query.rs
@@ -15,8 +15,9 @@
 
 //! Schema queries for projection compilers.
 //!
-//! [`SchemaQuery::resolve`] answers what a path *is*; [`SchemaQuery::steps`]
-//! additionally answers how generated Rust reaches it, segment by segment.
+//! [`SchemaQuery::resolve`](crate::query::SchemaQuery::resolve) answers what a path *is*;
+//! [`SchemaQuery::steps`](crate::query::SchemaQuery::steps) additionally answers how generated
+//! Rust reaches it, segment by segment.
 
 use std::collections::HashMap;
 

--- a/tests/tests/test-metrics-oem-nvidia.rs
+++ b/tests/tests/test-metrics-oem-nvidia.rs
@@ -202,7 +202,8 @@ async fn processor_metrics_oem_nvidia_malformed_payload_is_parse_error(
     };
     assert!(
         err.to_string().contains("invalid type"),
-        "unexpected error: {err}"
+        "unexpected error: {}",
+        err
     );
 
     Ok(())
@@ -275,7 +276,8 @@ async fn memory_metrics_oem_nvidia_malformed_payload_is_parse_error(
     };
     assert!(
         err.to_string().contains("invalid type"),
-        "unexpected error: {err}"
+        "unexpected error: {}",
+        err
     );
 
     Ok(())


### PR DESCRIPTION
Pass assertion errors as explicit formatting arguments and qualify `SchemaQuery` method links so the compiler and rustdoc resolve them correctly -- they have been generating warnings when running `make ci`.