### PR TITLE
chore: repoint repository URL to dsx-ai-factory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 license = "Apache-2.0"
-repository = "https://github.com/NVIDIA/nv-redfish"
+repository = "https://github.com/dsx-ai-factory/nv-redfish"
 description = "Rust implementation of Redfish API for BMC management"
 readme = "README.md"
 edition = "2018"


### PR DESCRIPTION
Post-transfer cleanup: `Cargo.toml` `repository` still pointed at the old `NVIDIA/nv-redfish` path. Repoint to `dsx-ai-factory/nv-redfish` so published crate metadata and git-dependency consumers reference the canonical path.

Non-urgent (the GitHub redirect keeps the old URL resolving), but fixes stale package metadata after the SCM transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the repository’s workspace URL to reflect its new location.
  * No functional configuration changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->