### PR TITLE
feat(redfish): prefer NVIDIA DPU reset for force restart

### DIFF
--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -38,6 +38,7 @@ use futures_util::Stream;
 use futures_util::StreamExt as _;
 use http::header;
 use http::HeaderMap;
+use nv_redfish_core::ActionError;
 use nv_redfish_core::AsyncTask;
 use nv_redfish_core::BoxTryStream;
 use nv_redfish_core::DataStream;
@@ -174,6 +175,19 @@ impl StdErr for BmcError {
             Self::DecodeError(e) | Self::EncodeError(e) => Some(e),
             _ => None,
         }
+    }
+}
+
+impl ActionError for BmcError {
+    fn not_supported() -> Self {
+        Self::InvalidRequest("action is not supported".to_string())
+    }
+
+    fn is_not_found(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidResponse { status, .. } if *status == reqwest::StatusCode::NOT_FOUND
+        )
     }
 }
 
@@ -1505,6 +1519,28 @@ mod tests {
 
         let created_miss = BmcError::cache_miss();
         assert!(matches!(created_miss, BmcError::CacheMiss));
+    }
+
+    #[test]
+    fn action_error_classifies_only_not_found_responses() {
+        let url: Url = "http://example.com/redfish/v1/Actions/Test"
+            .parse()
+            .expect("valid URL");
+
+        for (status, expected) in [
+            (reqwest::StatusCode::NOT_FOUND, true),
+            (reqwest::StatusCode::INTERNAL_SERVER_ERROR, false),
+        ] {
+            let error = BmcError::InvalidResponse {
+                url: url.clone(),
+                status,
+                text: String::new(),
+            };
+
+            assert_eq!(error.is_not_found(), expected);
+        }
+
+        assert!(!BmcError::CacheMiss.is_not_found());
     }
 
     #[tokio::test]

--- a/bmc-mock/src/expect.rs
+++ b/bmc-mock/src/expect.rs
@@ -75,6 +75,12 @@ pub enum ExpectedRequest {
         request: JsonValue,
     },
 
+    /// Expected action whose target is not found by the service.
+    ActionNotFound {
+        target: ActionTarget,
+        request: JsonValue,
+    },
+
     /// Expected multipart update.
     MultipartUpdate {
         uri: String,
@@ -207,6 +213,16 @@ impl<E> Expect<E> {
                 request: from_str(&request.to_string()).expect("invalid json"),
             },
             response: Ok(from_str(&response.to_string()).expect("invalid json")),
+        }
+    }
+
+    pub fn action_not_found(uri: impl Display, request: impl Display) -> Self {
+        Expect {
+            request: ExpectedRequest::ActionNotFound {
+                target: ActionTarget::new(uri.to_string()),
+                request: from_str(&request.to_string()).expect("invalid json"),
+            },
+            response: Ok(JsonValue::Null),
         }
     }
 

--- a/bmc-mock/src/lib.rs
+++ b/bmc-mock/src/lib.rs
@@ -50,6 +50,7 @@ use serde_json::Error as JsonError;
 #[derive(Debug)]
 pub enum Error {
     NotSupported,
+    NotFound,
     ErrorResponse(Box<dyn StdError + Send + Sync>),
     MutexLock(String),
     NothingIsExpected,
@@ -72,6 +73,7 @@ impl Display for Error {
         match self {
             Self::ErrorResponse(err) => write!(f, "response: {err}"),
             Self::NotSupported => write!(f, "not supported"),
+            Self::NotFound => write!(f, "not found"),
             Self::MutexLock(err) => write!(f, "lock error: {err}"),
             Self::NothingIsExpected => {
                 write!(f, "nothing is expected to happen but something happened")
@@ -384,6 +386,10 @@ where
         let in_request = to_value(params).expect("json serializable");
         match expect {
             Expect {
+                request: ExpectedRequest::ActionNotFound { target, request },
+                ..
+            } if target == action.target && request == in_request => Err(Error::NotFound),
+            Expect {
                 request: ExpectedRequest::Action { target, request },
                 response,
             } if target == action.target && request == in_request => {
@@ -527,5 +533,9 @@ where
 impl ActionError for Error {
     fn not_supported() -> Self {
         Error::NotSupported
+    }
+
+    fn is_not_found(&self) -> bool {
+        matches!(self, Error::NotFound)
     }
 }

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -117,6 +117,12 @@ impl<T, R> Debug for Action<T, R> {
 pub trait ActionError {
     /// Create an error when the action is not supported.
     fn not_supported() -> Self;
+
+    /// Returns whether the Redfish service reported that the action target was
+    /// not found.
+    fn is_not_found(&self) -> bool {
+        false
+    }
 }
 
 impl<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'de> Deserialize<'de>> Action<T, R> {

--- a/redfish/src/chassis/item.rs
+++ b/redfish/src/chassis/item.rs
@@ -222,7 +222,7 @@ impl<B: Bmc> Chassis<B> {
             return Ok(None);
         };
 
-        action
+        match action
             .run(
                 self.bmc.as_ref(),
                 &ForceDpuResetRequest {
@@ -230,8 +230,11 @@ impl<B: Bmc> Chassis<B> {
                 },
             )
             .await
-            .map(Some)
-            .map_err(Error::Bmc)
+        {
+            Ok(response) => Ok(Some(response)),
+            Err(error) if nv_redfish_core::ActionError::is_not_found(&error) => Ok(None),
+            Err(error) => Err(Error::Bmc(error)),
+        }
     }
 
     /// Get hardware identifier of the network adpater.

--- a/redfish/src/chassis/item.rs
+++ b/redfish/src/chassis/item.rs
@@ -68,6 +68,23 @@ use crate::sensor::SensorLink;
 #[cfg(feature = "oem-nvidia")]
 use std::convert::identity;
 
+#[cfg(all(feature = "oem-nvidia", feature = "computer-systems"))]
+const NVIDIA_RESET_ACTION: &str = "#NvidiaChassis.Reset";
+
+#[cfg(all(feature = "oem-nvidia", feature = "computer-systems"))]
+#[derive(serde::Serialize)]
+struct ForceDpuResetRequest {
+    #[serde(rename = "ResetType")]
+    reset_type: NvidiaChassisResetType,
+}
+
+#[cfg(all(feature = "oem-nvidia", feature = "computer-systems"))]
+#[derive(serde::Serialize)]
+enum NvidiaChassisResetType {
+    #[serde(rename = "ForceDpuReset")]
+    ForceDpuReset,
+}
+
 #[doc(hidden)]
 pub enum ChassisTag {}
 
@@ -173,6 +190,47 @@ impl<B: Bmc> Chassis<B> {
         actions
             .reset(self.bmc.as_ref(), reset_type)
             .await
+            .map_err(Error::Bmc)
+    }
+
+    #[cfg(all(feature = "oem-nvidia", feature = "computer-systems"))]
+    pub(crate) async fn oem_nvidia_force_dpu_reset(
+        &self,
+    ) -> Result<Option<ModificationResponse<()>>, Error<B>>
+    where
+        B::Error: nv_redfish_core::ActionError,
+    {
+        let Some(oem_actions) = self
+            .data
+            .actions
+            .as_ref()
+            .and_then(|actions| actions.oem.as_ref())
+        else {
+            return Ok(None);
+        };
+        let Some(action) = oem_actions
+            .additional_properties
+            .get(NVIDIA_RESET_ACTION)
+            .map(|value| {
+                serde_json::from_value::<nv_redfish_core::Action<ForceDpuResetRequest, ()>>(
+                    value.clone(),
+                )
+            })
+            .transpose()
+            .map_err(Error::Json)?
+        else {
+            return Ok(None);
+        };
+
+        action
+            .run(
+                self.bmc.as_ref(),
+                &ForceDpuResetRequest {
+                    reset_type: NvidiaChassisResetType::ForceDpuReset,
+                },
+            )
+            .await
+            .map(Some)
             .map_err(Error::Bmc)
     }
 

--- a/redfish/src/computer_system/item.rs
+++ b/redfish/src/computer_system/item.rs
@@ -38,6 +38,8 @@ use std::convert::identity;
 use std::sync::Arc;
 use tagged_types::TaggedType;
 
+#[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+use crate::chassis::Chassis;
 #[cfg(feature = "bios")]
 use crate::computer_system::Bios;
 #[cfg(feature = "boot-options")]
@@ -50,6 +52,8 @@ use crate::computer_system::Processor;
 use crate::computer_system::SecureBoot;
 #[cfg(feature = "storages")]
 use crate::computer_system::Storage;
+#[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+use crate::core::ODataId;
 #[cfg(feature = "ethernet-interfaces")]
 use crate::ethernet_interface::EthernetInterfaceCollection;
 #[cfg(feature = "log-services")]
@@ -58,6 +62,8 @@ use crate::log_service::LogService;
 use crate::oem::lenovo::computer_system::LenovoComputerSystem;
 #[cfg(feature = "oem-nvidia")]
 use crate::oem::nvidia::NvidiaComputerSystem;
+#[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+use crate::schema::chassis_collection::ChassisCollection as ChassisCollectionSchema;
 
 #[doc(hidden)]
 pub enum ComputerSystemTag {}
@@ -111,6 +117,8 @@ pub struct ComputerSystem<B: Bmc> {
     #[allow(dead_code)] // feature-enabled...
     bmc: NvBmc<B>,
     data: Arc<ComputerSystemSchema>,
+    #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+    chassis_collection_id: Option<ODataId>,
 }
 
 impl<B: Bmc> ComputerSystem<B> {
@@ -119,6 +127,9 @@ impl<B: Bmc> ComputerSystem<B> {
         bmc: &NvBmc<B>,
         nav: &NavProperty<ComputerSystemSchema>,
         read_patch_fn: Option<&ReadPatchFn>,
+        #[cfg(all(feature = "chassis", feature = "oem-nvidia"))] chassis_collection_id: Option<
+            ODataId,
+        >,
     ) -> Result<Self, Error<B>> {
         if let Some(read_patch_fn) = read_patch_fn {
             Payload::get(bmc.as_ref(), nav, read_patch_fn.as_ref()).await
@@ -128,6 +139,8 @@ impl<B: Bmc> ComputerSystem<B> {
         .map(|data| Self {
             bmc: bmc.clone(),
             data,
+            #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+            chassis_collection_id,
         })
     }
 
@@ -190,6 +203,10 @@ impl<B: Bmc> ComputerSystem<B> {
 
     /// Reset this computer system.
     ///
+    /// A `ForceRestart` prefers the NVIDIA OEM DPU reset when it is advertised
+    /// by the system's matching chassis. If that action is not advertised, the
+    /// standard `ComputerSystem.Reset` action is used.
+    ///
     /// # Errors
     ///
     /// Returns an error if the system does not support the `Reset` action or
@@ -201,6 +218,13 @@ impl<B: Bmc> ComputerSystem<B> {
     where
         B::Error: nv_redfish_core::ActionError,
     {
+        #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+        if reset_type == Some(ResetType::ForceRestart) {
+            if let Some(response) = self.try_oem_nvidia_force_dpu_reset().await? {
+                return Ok(response);
+            }
+        }
+
         let actions = self
             .data
             .actions
@@ -215,6 +239,33 @@ impl<B: Bmc> ComputerSystem<B> {
             .reset(self.bmc.as_ref(), reset_type)
             .await
             .map_err(Error::Bmc)
+    }
+
+    #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+    async fn try_oem_nvidia_force_dpu_reset(
+        &self,
+    ) -> Result<Option<ModificationResponse<()>>, Error<B>>
+    where
+        B::Error: nv_redfish_core::ActionError,
+    {
+        let Some(chassis_collection_id) = &self.chassis_collection_id else {
+            return Ok(None);
+        };
+        let chassis_collection =
+            NavProperty::<ChassisCollectionSchema>::new_reference(chassis_collection_id.clone())
+                .get(self.bmc.as_ref())
+                .await
+                .map_err(Error::Bmc)?;
+        let Some(chassis_nav) = chassis_collection
+            .members
+            .iter()
+            .find(|member| member.id().last_segment() == Some(*self.id().inner()))
+        else {
+            return Ok(None);
+        };
+        let chassis = Chassis::new(&self.bmc, chassis_nav).await?;
+
+        chassis.oem_nvidia_force_dpu_reset().await
     }
 
     /// An array of `BootOptionReference` strings that represent the persistent boot order for with this
@@ -271,6 +322,8 @@ impl<B: Bmc> ComputerSystem<B> {
                 Ok(Self {
                     bmc: self.bmc.clone(),
                     data,
+                    #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+                    chassis_collection_id: self.chassis_collection_id.clone(),
                 })
             })
             .await

--- a/redfish/src/computer_system/mod.rs
+++ b/redfish/src/computer_system/mod.rs
@@ -101,6 +101,8 @@ pub struct SystemCollection<B: Bmc> {
     bmc: NvBmc<B>,
     collection: Arc<ComputerSystemCollectionSchema>,
     read_patch_fn: Option<ReadPatchFn>,
+    #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+    chassis_collection_id: Option<nv_redfish_core::ODataId>,
 }
 
 impl<B: Bmc> SystemCollection<B> {
@@ -131,6 +133,8 @@ impl<B: Bmc> SystemCollection<B> {
             .then(|| Arc::new(move |v| patches.iter().fold(v, |acc, f| f(acc))) as ReadPatchFn);
         let filters_fn = (!filters.is_empty())
             .then(move || Arc::new(move |v: &JsonValue| filters.iter().any(|f| f(v))) as FilterFn);
+        #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+        let chassis_collection_id = root.root.chassis.as_ref().map(|nav| nav.id().clone());
 
         if let Some(collection_ref) = &root.root.systems {
             Self::expand_collection(
@@ -155,6 +159,8 @@ impl<B: Bmc> SystemCollection<B> {
                 bmc: bmc.clone(),
                 collection,
                 read_patch_fn,
+                #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+                chassis_collection_id,
             })
         })
     }
@@ -167,7 +173,16 @@ impl<B: Bmc> SystemCollection<B> {
     pub async fn members(&self) -> Result<Vec<ComputerSystem<B>>, Error<B>> {
         let mut members = Vec::new();
         for m in &self.collection.members {
-            members.push(ComputerSystem::new(&self.bmc, m, self.read_patch_fn.as_ref()).await?);
+            members.push(
+                ComputerSystem::new(
+                    &self.bmc,
+                    m,
+                    self.read_patch_fn.as_ref(),
+                    #[cfg(all(feature = "chassis", feature = "oem-nvidia"))]
+                    self.chassis_collection_id.clone(),
+                )
+                .await?,
+            );
         }
         Ok(members)
     }

--- a/tests/tests/test-computer-system-oem-nvidia.rs
+++ b/tests/tests/test-computer-system-oem-nvidia.rs
@@ -16,9 +16,12 @@
 
 use nv_redfish::computer_system::ComputerSystem;
 use nv_redfish::oem::nvidia::computer_system::Mode;
+use nv_redfish::resource::ResetType;
 use nv_redfish::ServiceRoot;
+use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataId;
 use nv_redfish_tests::json_merge;
+use nv_redfish_tests::redfish_action_payload;
 use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
@@ -33,11 +36,60 @@ const SERVICE_ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_13_0.ServiceRoot";
 const SYSTEM_COLLECTION_DATA_TYPE: &str = "#ComputerSystemCollection.ComputerSystemCollection";
 const SYSTEM_DATA_TYPE: &str = "#ComputerSystem.v1_19_0.ComputerSystem";
 const NVIDIA_SYSTEM_DATA_TYPE: &str = "#NvidiaComputerSystem.v1_0_0.NvidiaComputerSystem";
+const CHASSIS_COLLECTION_DATA_TYPE: &str = "#ChassisCollection.ChassisCollection";
+const CHASSIS_DATA_TYPE: &str = "#Chassis.v1_22_0.Chassis";
 
 /// Service-root identity of an NVIDIA DPU.
 const DPU_VENDOR: &str = "Nvidia";
 const DPU_PRODUCT: &str = "Nvidia-BMCMezz";
 const BF3_DPU_PRODUCT: &str = "BlueField-3 DPU";
+
+#[test]
+async fn force_restart_prefers_advertised_nvidia_dpu_reset() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = bluefield_4_ids();
+    let standard_target = format!("{}/Actions/ComputerSystem.Reset", ids.system_id);
+    let base = system_payload(&ids, None);
+    let standard_action = redfish_action_payload("ComputerSystem.Reset", &standard_target);
+    let system = get_system(bmc.clone(), &ids, json_merge([&base, &standard_action])).await?;
+    let oem_target = expect_bluefield_chassis(&bmc, &ids, true);
+    bmc.expect(Expect::action(
+        &oem_target,
+        json!({ "ResetType": "ForceDpuReset" }),
+        json!(null),
+    ));
+
+    assert!(matches!(
+        system.reset(Some(ResetType::ForceRestart)).await?,
+        ModificationResponse::Entity(())
+    ));
+
+    Ok(())
+}
+
+#[test]
+async fn force_restart_falls_back_when_nvidia_dpu_reset_is_absent() -> Result<(), Box<dyn StdError>>
+{
+    let bmc = Arc::new(Bmc::default());
+    let ids = bluefield_4_ids();
+    let standard_target = format!("{}/Actions/ComputerSystem.Reset", ids.system_id);
+    let base = system_payload(&ids, None);
+    let standard_action = redfish_action_payload("ComputerSystem.Reset", &standard_target);
+    let system = get_system(bmc.clone(), &ids, json_merge([&base, &standard_action])).await?;
+    expect_bluefield_chassis(&bmc, &ids, false);
+    bmc.expect(Expect::action(
+        &standard_target,
+        json!({ "ResetType": "ForceRestart" }),
+        json!(null),
+    ));
+
+    assert!(matches!(
+        system.reset(Some(ResetType::ForceRestart)).await?,
+        ModificationResponse::Entity(())
+    ));
+
+    Ok(())
+}
 
 #[test]
 async fn oem_nvidia_dpu_missing_odata_id_in_oem_target_payload() -> Result<(), Box<dyn StdError>> {
@@ -393,6 +445,7 @@ async fn expect_service_root(
                 }
             },
             "Systems": { ODATA_ID: &ids.systems_id },
+            "Chassis": { ODATA_ID: format!("{}/Chassis", ids.root_id) },
             "Links": {
                 "Sessions": {
                     ODATA_ID: format!("{}/SessionService/Sessions", ids.root_id),
@@ -423,12 +476,69 @@ fn ids() -> Ids {
     }
 }
 
+fn bluefield_4_ids() -> Ids {
+    let root_id = ODataId::service_root();
+    let systems_id = format!("{root_id}/Systems");
+    let system_id = format!("{systems_id}/BlueField_0");
+    let nvidia_oem_id = format!("{system_id}/Oem/Nvidia");
+    Ids {
+        root_id,
+        systems_id,
+        system_id,
+        nvidia_oem_id,
+    }
+}
+
+fn expect_bluefield_chassis(bmc: &Bmc, ids: &Ids, with_reset_action: bool) -> String {
+    let chassis_collection_id = format!("{}/Chassis", ids.root_id);
+    let chassis_id = format!("{chassis_collection_id}/BlueField_0");
+    let action_target = format!("{chassis_id}/Actions/Oem/NvidiaChassis.Reset");
+    bmc.expect(Expect::get(
+        &chassis_collection_id,
+        json!({
+            ODATA_ID: &chassis_collection_id,
+            ODATA_TYPE: CHASSIS_COLLECTION_DATA_TYPE,
+            "Id": "Chassis",
+            "Name": "Chassis Collection",
+            "Members": [{ ODATA_ID: &chassis_id }]
+        }),
+    ));
+    let actions = if with_reset_action {
+        json!({
+            "Actions": {
+                "Oem": {
+                    "#NvidiaChassis.Reset": {
+                        "target": &action_target
+                    }
+                }
+            }
+        })
+    } else {
+        json!({ "Actions": { "Oem": {} } })
+    };
+    let chassis = json!({
+        ODATA_ID: &chassis_id,
+        ODATA_TYPE: CHASSIS_DATA_TYPE,
+        "Id": "BlueField_0",
+        "Name": "BlueField_0",
+        "ChassisType": "Card"
+    });
+    bmc.expect(Expect::get(&chassis_id, json_merge([&chassis, &actions])));
+
+    action_target
+}
+
 fn system_payload(ids: &Ids, nvidia_oem: Option<Value>) -> Value {
+    let name = ids
+        .system_id
+        .rsplit('/')
+        .next()
+        .unwrap_or(ids.system_id.as_str());
     let base = json!({
         ODATA_ID: &ids.system_id,
         ODATA_TYPE: SYSTEM_DATA_TYPE,
-        "Id": "Bluefield",
-        "Name": "Bluefield",
+        "Id": name,
+        "Name": name,
         "Status": {
             "Health": "OK",
             "State": "Enabled"

--- a/tests/tests/test-computer-system-oem-nvidia.rs
+++ b/tests/tests/test-computer-system-oem-nvidia.rs
@@ -92,6 +92,34 @@ async fn force_restart_falls_back_when_nvidia_dpu_reset_is_absent() -> Result<()
 }
 
 #[test]
+async fn force_restart_falls_back_when_nvidia_dpu_reset_target_is_stale(
+) -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = bluefield_4_ids();
+    let standard_target = format!("{}/Actions/ComputerSystem.Reset", ids.system_id);
+    let base = system_payload(&ids, None);
+    let standard_action = redfish_action_payload("ComputerSystem.Reset", &standard_target);
+    let system = get_system(bmc.clone(), &ids, json_merge([&base, &standard_action])).await?;
+    let oem_target = expect_bluefield_chassis(&bmc, &ids, true);
+    bmc.expect(Expect::action_not_found(
+        &oem_target,
+        json!({ "ResetType": "ForceDpuReset" }),
+    ));
+    bmc.expect(Expect::action(
+        &standard_target,
+        json!({ "ResetType": "ForceRestart" }),
+        json!(null),
+    ));
+
+    assert!(matches!(
+        system.reset(Some(ResetType::ForceRestart)).await?,
+        ModificationResponse::Entity(())
+    ));
+
+    Ok(())
+}
+
+#[test]
 async fn oem_nvidia_dpu_missing_odata_id_in_oem_target_payload() -> Result<(), Box<dyn StdError>> {
     // Platform under test: NVIDIA BlueField DPU.
     // Quirk under test: missing @odata.id in OEM target payload.


### PR DESCRIPTION
Using the "/redfish/v1/Chassis/BlueField_0/Actions/Oem/NvidiaChassis.Reset" endpoint is the official way for BF4 to do the reset.
The standard redfish ForceRestart method may not work with BF4 DPU.
To handle this situation, the nv-redfish would try to use "/redfish/v1/Chassis/BlueField_0/Actions/Oem/NvidiaChassis.Reset" endpoint first to reset the BF4 DPU if the endpoint exists. If the endpoint does not exist, the nv-redfish would be fallback to standard ForceRestart method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA BlueField-4 DPU reset support through the chassis OEM reset action.
  * Computer system restarts fall back to the standard reset action when the NVIDIA-specific action is unavailable or not found.
* **Bug Fixes**
  * Preserved chassis information during computer-system updates to keep NVIDIA reset handling available.
  * Improved recognition of unavailable reset actions and missing action targets.
* **Tests**
  * Added coverage for NVIDIA-specific resets and standard reset fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->