### PR TITLE
feat(nv-redfish, csdl-compiler): support NVIDIA chassis OEM action

### DIFF
--- a/bmc-http/build.rs
+++ b/bmc-http/build.rs
@@ -48,6 +48,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
         root_csdls,
         resolve_csdls,
         entity_type_patterns: Vec::new(),
+        action_patterns: Vec::new(),
         rigid_array_patterns: Vec::new(),
     })?;
 

--- a/csdl-compiler/src/commands.rs
+++ b/csdl-compiler/src/commands.rs
@@ -27,6 +27,8 @@
 //! - Optimize the compiled set and run the Rust generator.
 //! - Pretty-print the resulting syntax and write it to the `output` path.
 
+use crate::compiler::ActionFilter;
+use crate::compiler::ActionFilterPattern;
 use crate::compiler::Config as CompilerConfig;
 use crate::compiler::EntityTypeFilter;
 use crate::compiler::EntityTypeFilterPattern;
@@ -116,6 +118,13 @@ pub enum Commands {
         /// `*.*.Entity1|Entity2` - `EntityType1` or `EntityType2` from any versions of any namespaces.
         #[arg(short = 'p', long = "pattern")]
         entity_type_patterns: Vec<EntityTypeFilterPattern>,
+        /// Patterns of actions to include in the OEM root set.
+        ///
+        /// Pattern is a wildcard over the action's defining namespace and name.
+        /// Example: `NvidiaChassis.*` selects every action in the
+        /// `NvidiaChassis` namespace. If empty, no actions are compiled.
+        #[arg(long = "action-pattern")]
+        action_patterns: Vec<ActionFilterPattern>,
         /// Patterns of properties that must be compiled with rigid array support
         ///
         /// Pattern is a wildcard over the qualified name.
@@ -174,6 +183,7 @@ fn process_command_inner(
                             entity_type_patterns.clone(),
                         ),
                         rigid_array_filter: PropertyFilter::new(rigid_array_patterns.clone()),
+                        ..CompilerConfig::default()
                     },
                 )
                 .map_err(Error::compile_error)?;
@@ -199,6 +209,7 @@ fn process_command_inner(
             resolve_csdls,
             output,
             entity_type_patterns,
+            action_patterns,
             rigid_array_patterns,
         } => {
             if root_csdls.is_empty() {
@@ -210,6 +221,7 @@ fn process_command_inner(
                     entity_type_filter: EntityTypeFilter::new_permissive(
                         entity_type_patterns.clone(),
                     ),
+                    action_filter: ActionFilter::new_restrictive(action_patterns.clone()),
                     rigid_array_filter: PropertyFilter::new(rigid_array_patterns.clone()),
                 })
                 .map_err(Error::compile_error)?;

--- a/csdl-compiler/src/compiler/action.rs
+++ b/csdl-compiler/src/compiler/action.rs
@@ -33,6 +33,7 @@ use crate::edmx::ActionName;
 use crate::edmx::ParameterName;
 use crate::redfish::annotations::RedfishAnnotations as _;
 use crate::IsNullable;
+use crate::IsRequired;
 use crate::OneOrCollection;
 
 /// Compiled action.
@@ -146,11 +147,20 @@ pub(crate) fn compile_action<'a>(
         }
         .map_err(Box::new)
         .map_err(|e| Error::ActionParameter(&p.name, e))?;
+        let nullable = p.nullable.unwrap_or(IsNullable::new(false));
+        // Redfish Specification 11.1.5.3 uses an explicit
+        // `Nullable="false"` on an action parameter to mark it as required
+        // in the request body. Preserve the generic `Redfish.Required`
+        // annotation as an additional way to express the same constraint.
+        let required = IsRequired::new(
+            p.is_required().into_inner()
+                || p.nullable.is_some_and(|nullable| !nullable.into_inner()),
+        );
         params.push(Parameter {
             name: &p.name,
             ptype,
-            nullable: p.nullable.unwrap_or(IsNullable::new(false)),
-            required: p.is_required(),
+            nullable,
+            required,
             odata: OData::new(MustHaveId::new(false), p),
         });
         Ok((cstack.merge(compiled), params))

--- a/csdl-compiler/src/compiler/context.rs
+++ b/csdl-compiler/src/compiler/context.rs
@@ -48,14 +48,22 @@ pub struct Context<'a> {
 }
 
 /// Compilation configuration.
-/// Filter and include rules for entity types during compilation.
+/// Filter and include rules applied during compilation.
 #[derive(Default)]
 pub struct Config {
     /// Entity type filter applied during compilation.
     pub entity_type_filter: EntityTypeFilter,
+    /// Action filter applied during compilation.
+    pub action_filter: ActionFilter,
     /// Array properties that should be generated as rigid.
     pub rigid_array_filter: PropertyFilter,
 }
+
+/// Action filter specified by wildcard patterns.
+pub type ActionFilter = EntityTypeFilter;
+
+/// Qualified-name pattern for an action's defining namespace and name.
+pub type ActionFilterPattern = EntityTypeFilterPattern;
 
 /// Entity type filter specified by wildcard patterns.
 pub struct EntityTypeFilter {
@@ -73,8 +81,8 @@ impl Default for EntityTypeFilter {
 }
 
 impl EntityTypeFilter {
-    /// Create a new filter from a list of patterns. If patterns empty
-    /// then matches anything.
+    /// Create a new filter from a list of patterns. If patterns are empty,
+    /// matches nothing.
     #[must_use]
     pub const fn new_restrictive(patterns: Vec<EntityTypeFilterPattern>) -> Self {
         Self {
@@ -82,8 +90,8 @@ impl EntityTypeFilter {
             permissive: false,
         }
     }
-    /// Create a new filter from a list of patterns. If patterns empty
-    /// then matches nothing.
+    /// Create a new filter from a list of patterns. If patterns are empty,
+    /// matches anything.
     #[must_use]
     pub const fn new_permissive(patterns: Vec<EntityTypeFilterPattern>) -> Self {
         Self {

--- a/csdl-compiler/src/compiler/mod.rs
+++ b/csdl-compiler/src/compiler/mod.rs
@@ -102,6 +102,10 @@ pub use compiled::TypeActions;
 #[doc(inline)]
 pub use complex_type::ComplexType;
 #[doc(inline)]
+pub use context::ActionFilter;
+#[doc(inline)]
+pub use context::ActionFilterPattern;
+#[doc(inline)]
 pub use context::Config;
 #[doc(inline)]
 pub use context::Context;
@@ -158,6 +162,7 @@ pub use traits::PropertiesManipulation;
 
 use crate::compiler::odata::MustHaveId;
 use crate::compiler::odata::MustHaveType;
+use crate::edmx::Action as EdmxAction;
 use crate::edmx::Edmx;
 use crate::edmx::Schema;
 use crate::edmx::SimpleIdentifier;
@@ -237,13 +242,14 @@ impl SchemaBundle {
 
     /// Compile multiple schemas, resolving all type dependencies.
     ///
-    /// The root set includes all entity and complex types.
+    /// The root set includes all entity and complex types from root documents,
+    /// plus the binding types of selected actions.
     ///
     /// # Errors
     ///
     /// Returns a compile error if any type cannot be resolved.
     pub fn compile_all(&self, config: Config) -> Result<Compiled<'_>, Error<'_>> {
-        let root_set = self.root_set_all();
+        let root_set = self.root_set_all(&config.action_filter);
         let ctx = Context {
             schema_index: SchemaIndex::build(&self.edmx_docs)?,
             config,
@@ -338,7 +344,7 @@ impl SchemaBundle {
         })
     }
 
-    fn root_set_all(&self) -> RootSet<'_> {
+    fn root_set_all(&self, action_filter: &ActionFilter) -> RootSet<'_> {
         let mut entity_types: Vec<_> = self
             .edmx_docs
             .iter()
@@ -379,12 +385,36 @@ impl SchemaBundle {
                     .collect::<Vec<_>>()
             })
             .collect();
+
+        // A selected action is a compilation root, so its binding type is a
+        // root as well. This is primarily needed by OEM actions bound to a
+        // standard OemActions type supplied in a resolution-only document.
+        if let Some(root_set_threshold) = self.root_set_threshold {
+            complex_types.extend(
+                self.edmx_docs
+                    .iter()
+                    .take(root_set_threshold)
+                    .flat_map(|edmx| edmx.data_services.schemas.iter())
+                    .flat_map(|schema| {
+                        schema
+                            .actions
+                            .iter()
+                            .filter(move |action| {
+                                action.is_bound.into_inner()
+                                    && Self::action_matches_filter(schema, action, action_filter)
+                            })
+                            .filter_map(|action| action.parameters.first())
+                            .map(|binding| QualifiedName::from(binding.ptype.qualified_type_name()))
+                    }),
+            );
+        }
         // Schemas store types in hash maps, and iteration order must not
         // decide compile order: which member of a reference cycle sees
         // the provisional type info — and with it generated output —
         // would otherwise vary run to run.
         entity_types.sort_unstable();
         complex_types.sort_unstable();
+        complex_types.dedup();
         RootSet {
             entity_types,
             complex_types,
@@ -428,14 +458,15 @@ impl SchemaBundle {
         // Compile actions for all extracted types
         self.edmx_docs
             .iter()
-            .try_fold(stack, |stack, edmx| {
+            .enumerate()
+            .try_fold(stack, |stack, (document_index, edmx)| {
                 let cstack = stack.new_frame();
                 let compiled = edmx
                     .data_services
                     .schemas
                     .iter()
                     .try_fold(cstack, |stack, s| {
-                        Self::compile_schema_actions(s, ctx, stack.new_frame())
+                        self.compile_schema_actions(document_index, s, ctx, stack.new_frame())
                             .map(|v| stack.merge(v))
                     })?
                     .done();
@@ -450,12 +481,19 @@ impl SchemaBundle {
     }
 
     fn compile_schema_actions<'a>(
+        &'a self,
+        document_index: usize,
         s: &'a Schema,
         ctx: &Context<'a>,
         stack: Stack<'a, '_>,
     ) -> Result<Compiled<'a>, Error<'a>> {
         s.actions
             .iter()
+            .filter(|action| {
+                self.root_set_threshold
+                    .is_none_or(|threshold| document_index < threshold)
+                    && Self::action_matches_filter(s, action, &ctx.config.action_filter)
+            })
             .try_fold(stack, |stack, action| {
                 let compiled =
                     action::compile_action(action, Namespace::new(&s.namespace), ctx, &stack)
@@ -466,6 +504,14 @@ impl SchemaBundle {
             .map_err(Box::new)
             .map_err(|e| Error::Schema(&s.namespace, e))
             .map(Stack::done)
+    }
+
+    fn action_matches_filter(
+        schema: &Schema,
+        action: &EdmxAction,
+        action_filter: &ActionFilter,
+    ) -> bool {
+        action_filter.matches(&QualifiedName::new(&schema.namespace, action.name.inner()))
     }
 }
 

--- a/csdl-compiler/src/edmx/mod.rs
+++ b/csdl-compiler/src/edmx/mod.rs
@@ -123,7 +123,7 @@ pub type LocalTypeName = TaggedType<SimpleIdentifier, LocalTypeNameTag>;
 pub enum LocalTypeNameTag {}
 
 /// Name of the Action.
-pub type ActionName = TaggedType<String, ActionNameTag>;
+pub type ActionName = TaggedType<SimpleIdentifier, ActionNameTag>;
 #[doc(hidden)]
 #[derive(tagged_types::Tag)]
 #[implement(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/csdl-compiler/src/features_manifest.rs
+++ b/csdl-compiler/src/features_manifest.rs
@@ -29,6 +29,7 @@ use std::io::Error as IoError;
 use std::io::Read as _;
 use std::path::PathBuf;
 
+use crate::compiler::ActionFilterPattern;
 use crate::compiler::EntityTypeFilterPattern;
 use crate::compiler::PropertyPattern;
 
@@ -50,6 +51,16 @@ pub struct Collected<'a> {
     pub patterns: Vec<&'a EntityTypeFilterPattern>,
     pub root_patterns: Vec<&'a EntityTypeFilterPattern>,
     pub rigid_array_patterns: Vec<&'a PropertyPattern>,
+}
+
+/// OEM CSDLs and patterns collected for selected vendor features.
+#[derive(Default)]
+pub struct CollectedOem<'a> {
+    pub root_csdls: Vec<&'a String>,
+    pub resolve_csdls: Vec<&'a String>,
+    pub swordfish_resolve_csdls: Vec<&'a String>,
+    pub patterns: Vec<&'a EntityTypeFilterPattern>,
+    pub action_patterns: Vec<&'a ActionFilterPattern>,
 }
 
 impl FeaturesManifest {
@@ -127,24 +138,21 @@ impl FeaturesManifest {
         &'a self,
         vendor: &String,
         features: &[&String],
-    ) -> (
-        Vec<&'a String>, // root csdl
-        Vec<&'a String>, // resolve csdl (DMTF Redfish)
-        Vec<&'a String>, // resolve csdl (SNIA Swordfish)
-        Vec<&'a EntityTypeFilterPattern>,
-    ) {
-        self.oem_features.iter().fold(
-            (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
-            |(mut root, mut resolve, mut swordfish_resolve, mut patterns), f| {
+    ) -> CollectedOem<'a> {
+        self.oem_features
+            .iter()
+            .fold(CollectedOem::default(), |mut collected, f| {
                 if f.vendor == *vendor && features.contains(&&f.name) {
-                    root.extend(f.oem_csdl_files.iter());
-                    resolve.extend(f.csdl_files.iter());
-                    swordfish_resolve.extend(f.swordfish_csdl_files.iter());
-                    patterns.extend(f.patterns.iter());
+                    collected.root_csdls.extend(f.oem_csdl_files.iter());
+                    collected.resolve_csdls.extend(f.csdl_files.iter());
+                    collected
+                        .swordfish_resolve_csdls
+                        .extend(f.swordfish_csdl_files.iter());
+                    collected.patterns.extend(f.patterns.iter());
+                    collected.action_patterns.extend(f.action_patterns.iter());
                 }
-                (root, resolve, swordfish_resolve, patterns)
-            },
-        )
+                collected
+            })
     }
 }
 
@@ -186,6 +194,9 @@ pub struct OemFeature {
     /// compilation.
     #[serde(default)]
     pub patterns: Vec<EntityTypeFilterPattern>,
+    /// Actions to include in the OEM root set.
+    #[serde(default)]
+    pub action_patterns: Vec<ActionFilterPattern>,
 }
 
 /// Errors reading or parsing the manifest.
@@ -229,6 +240,7 @@ mod tests {
                 csdl_files: Vec::new(),
                 swordfish_csdl_files: Vec::new(),
                 patterns: Vec::new(),
+                action_patterns: Vec::new(),
             })
             .collect(),
         };

--- a/csdl-compiler/src/generator/rust/action_name.rs
+++ b/csdl-compiler/src/generator/rust/action_name.rs
@@ -54,7 +54,7 @@ impl ToTokens for ActionName<'_> {
 
 impl Display for ActionName<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str(&casemungler::to_snake(self.0.inner()))
+        f.write_str(&casemungler::to_snake(self.0.inner().inner()))
     }
 }
 

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -304,6 +304,7 @@ mod tests {
               </Action>
               <Action Name="AuxPowerReset" IsBound="true">
                 <Parameter Name="Chassis" Type="Chassis.v1_0_0.OemActions"/>
+                <Parameter Name="Mode" Type="Edm.String"/>
               </Action>
             </Schema>
             <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OtherOem">
@@ -375,6 +376,16 @@ mod tests {
                 ..CompilerConfig::default()
             })
             .map_err(|error| error.to_string())?;
+        let action = |name| {
+            compiled
+                .actions
+                .values()
+                .flat_map(|actions| actions.values())
+                .find(|action| action.name.inner().inner() == name)
+                .unwrap_or_else(|| panic!("{} action is compiled", name))
+        };
+        assert!(action("Reset").parameters[0].required.into_inner());
+        assert!(!action("AuxPowerReset").parameters[0].required.into_inner());
         let compiled = optimize(compiled, &OptimizerConfig::default());
         let generated = RustGenerator::new(compiled, Config::default())
             .map_err(|error| error.to_string())?
@@ -395,6 +406,7 @@ mod tests {
         assert!(generated.contains("pub struct ChassisAuxPowerResetAction"));
         assert!(reset_action.contains("pub reset_type"));
         assert!(reset_action.contains("NvidiaChassisResetType"));
+        assert!(!reset_action.contains("Option"));
         assert!(oem_actions.contains("pub reset"));
         assert!(oem_actions.contains("pub aux_power_reset"));
         assert!(generated.contains("pub async fn reset"));

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -236,9 +236,12 @@ impl<'a> RustGenerator<'a> {
 mod tests {
     use super::Config;
     use super::RustGenerator;
+    use crate::compiler::ActionFilter;
     use crate::compiler::Config as CompilerConfig;
     use crate::compiler::SchemaBundle;
     use crate::edmx::Edmx;
+    use crate::optimizer::optimize;
+    use crate::optimizer::Config as OptimizerConfig;
     use quote::quote;
 
     #[test]
@@ -286,6 +289,118 @@ mod tests {
 
             assert_eq!(generated.contains(&serialize_and_deserialize), enabled);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn root_oem_action_bound_to_resolve_only_type_respects_filter() -> Result<(), String> {
+        let oem_schema = r#"<edmx:Edmx Version="4.0">
+          <edmx:DataServices>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NvidiaChassis">
+              <Action Name="Reset" IsBound="true">
+                <Parameter Name="Chassis" Type="Chassis.v1_0_0.OemActions"/>
+                <Parameter Name="ResetType" Type="NvidiaChassis.v1_0_0.NvidiaChassisResetType" Nullable="false"/>
+              </Action>
+              <Action Name="AuxPowerReset" IsBound="true">
+                <Parameter Name="Chassis" Type="Chassis.v1_0_0.OemActions"/>
+              </Action>
+            </Schema>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OtherOem">
+              <Action Name="Ignored" IsBound="true">
+                <Parameter Name="Chassis" Type="Chassis.v1_0_0.OemActions"/>
+              </Action>
+            </Schema>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NvidiaChassis.v1_0_0">
+              <EnumType Name="NvidiaChassisResetType">
+                <Member Name="ForceDpuReset"/>
+              </EnumType>
+            </Schema>
+          </edmx:DataServices>
+        </edmx:Edmx>"#;
+        let resolve_schema = r#"<edmx:Edmx Version="4.0">
+          <edmx:DataServices>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Chassis.v1_0_0">
+              <ComplexType Name="OemActions"/>
+            </Schema>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResolveOnly">
+              <ComplexType Name="OemActions"/>
+              <Action Name="Ignored" IsBound="true">
+                <Parameter Name="ResolveOnly" Type="ResolveOnly.OemActions"/>
+              </Action>
+            </Schema>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource">
+              <EntityType Name="Resource" Abstract="true"/>
+              <EntityType Name="ResourceCollection" Abstract="true"/>
+            </Schema>
+            <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings">
+              <ComplexType Name="Settings"/>
+              <ComplexType Name="PreferredApplyTime"/>
+            </Schema>
+          </edmx:DataServices>
+        </edmx:Edmx>"#;
+
+        let bundle = SchemaBundle {
+            edmx_docs: vec![
+                Edmx::parse(oem_schema).map_err(|error| error.to_string())?,
+                Edmx::parse(resolve_schema).map_err(|error| error.to_string())?,
+            ],
+            root_set_threshold: Some(1),
+        };
+        let compiled_without_action_patterns = bundle
+            .compile_all(CompilerConfig {
+                action_filter: ActionFilter::new_restrictive(Vec::new()),
+                ..CompilerConfig::default()
+            })
+            .map_err(|error| error.to_string())?;
+        let compiled_without_action_patterns = optimize(
+            compiled_without_action_patterns,
+            &OptimizerConfig::default(),
+        );
+        let generated_without_action_patterns =
+            RustGenerator::new(compiled_without_action_patterns, Config::default())
+                .map_err(|error| error.to_string())?
+                .generate()
+                .to_string();
+
+        assert!(!generated_without_action_patterns.contains("ChassisResetAction"));
+        assert!(!generated_without_action_patterns.contains("ChassisAuxPowerResetAction"));
+        assert!(!generated_without_action_patterns.contains("pub struct OemActions"));
+
+        let compiled = bundle
+            .compile_all(CompilerConfig {
+                action_filter: ActionFilter::new_restrictive(vec!["NvidiaChassis.*"
+                    .parse()
+                    .map_err(|error| format!("{error:?}"))?]),
+                ..CompilerConfig::default()
+            })
+            .map_err(|error| error.to_string())?;
+        let compiled = optimize(compiled, &OptimizerConfig::default());
+        let generated = RustGenerator::new(compiled, Config::default())
+            .map_err(|error| error.to_string())?
+            .generate()
+            .to_string();
+        let reset_action = generated
+            .split_once("pub struct ChassisResetAction")
+            .map(|(_, rest)| rest)
+            .and_then(|rest| rest.split_once('}').map(|(body, _)| body))
+            .expect("the OEM action request type is generated");
+        let oem_actions = generated
+            .split_once("pub struct OemActions")
+            .map(|(_, rest)| rest)
+            .and_then(|rest| rest.split_once('}').map(|(body, _)| body))
+            .expect("the action binding type is generated");
+
+        assert!(generated.contains("pub enum NvidiaChassisResetType"));
+        assert!(generated.contains("pub struct ChassisAuxPowerResetAction"));
+        assert!(reset_action.contains("pub reset_type"));
+        assert!(reset_action.contains("NvidiaChassisResetType"));
+        assert!(oem_actions.contains("pub reset"));
+        assert!(oem_actions.contains("pub aux_power_reset"));
+        assert!(generated.contains("pub async fn reset"));
+        assert!(generated.contains("pub async fn aux_power_reset"));
+        assert!(!generated.contains("ChassisIgnoredAction"));
+        assert!(!generated.contains("ResolveOnlyIgnoredAction"));
 
         Ok(())
     }

--- a/examples/explore-with-reqwest-bmc/src/main.rs
+++ b/examples/explore-with-reqwest-bmc/src/main.rs
@@ -126,9 +126,9 @@ async fn main() -> Result<(), BmcError> {
         .run(
             &bmc,
             &redfish_std::redfish::bios::BiosChangePasswordAction {
-                password_name: Some("admin".into()),
+                password_name: "admin".into(),
                 old_password: Some("admin1".into()),
-                new_password: Some("admin2".into()),
+                new_password: "admin2".into(),
             },
         )
         .await?;

--- a/examples/redfish-oem-contoso/build.rs
+++ b/examples/redfish-oem-contoso/build.rs
@@ -41,6 +41,11 @@ fn run() -> Result<(), Error> {
             .map(|v| v.parse())
             .collect::<Result<Vec<_>, _>>()
             .expect("must be successfuly parsed"),
+        action_patterns: ["ContosoAccountService.*"]
+            .iter()
+            .map(|v| v.parse())
+            .collect::<Result<Vec<_>, _>>()
+            .expect("must be successfuly parsed"),
         rigid_array_patterns: vec![],
     })?;
     Ok(())

--- a/redfish/build.rs
+++ b/redfish/build.rs
@@ -137,10 +137,10 @@ fn run() -> Result<(), Box<dyn StdError>> {
             continue;
         }
 
-        let (root_csdls, resolve_csdls, swordfish_resolve_csdls, patterns) =
-            manifest.collect_vendor_features(v, &vendor_features);
+        let oem_features = manifest.collect_vendor_features(v, &vendor_features);
 
-        let root_names = root_csdls
+        let root_names = oem_features
+            .root_csdls
             .iter()
             .map(|f| f.as_str())
             .collect::<std::collections::HashSet<_>>();
@@ -154,7 +154,8 @@ fn run() -> Result<(), Box<dyn StdError>> {
             .filter(|f| !root_names.contains(file_name(f)))
             .collect::<Vec<_>>();
 
-        let root_csdls = root_csdls
+        let root_csdls = oem_features
+            .root_csdls
             .iter()
             .map(|f| oem_schema(v, f))
             .collect::<Vec<_>>();
@@ -162,8 +163,13 @@ fn run() -> Result<(), Box<dyn StdError>> {
         let resolve_csdls = standard_csdls
             .iter()
             .cloned()
-            .chain(resolve_csdls.iter().map(|f| redfish_schema(f)))
-            .chain(swordfish_resolve_csdls.iter().map(|f| swordfish_schema(f)))
+            .chain(oem_features.resolve_csdls.iter().map(|f| redfish_schema(f)))
+            .chain(
+                oem_features
+                    .swordfish_resolve_csdls
+                    .iter()
+                    .map(|f| swordfish_schema(f)),
+            )
             .chain(unselected_oem)
             .collect::<std::collections::HashSet<_>>()
             .into_iter()
@@ -175,7 +181,8 @@ fn run() -> Result<(), Box<dyn StdError>> {
             output,
             root_csdls,
             resolve_csdls,
-            entity_type_patterns: patterns.into_iter().cloned().collect(),
+            entity_type_patterns: oem_features.patterns.into_iter().cloned().collect(),
+            action_patterns: oem_features.action_patterns.into_iter().cloned().collect(),
             rigid_array_patterns: vec![],
         })?;
     }

--- a/redfish/features.toml
+++ b/redfish/features.toml
@@ -644,6 +644,7 @@ patterns = [
     "NvidiaFirmwarePackageCollection.*.*",
     "NvidiaPersistentStorage.*.*",
 ]
+action_patterns = ["NvidiaPersistentStorage.*"]
 
 [[oem-features]]
 # NVIDIA log service, log entries and conditions.
@@ -803,6 +804,15 @@ patterns = [
     "NvidiaPscStateCollection.*.*",
     "NvidiaErrorInjection.*.*",
 ]
+action_patterns = [
+    "NvidiaDebugToken.*",
+    "NvidiaDebugTokenManagement.*",
+    "NvidiaDOT.*",
+    "NvidiaDOTManagement.*",
+    "NvidiaDOTBackupData.*",
+    "NvidiaRoTProtectedComponent.*",
+    "NvidiaErrorInjection.*",
+]
 
 [[oem-features]]
 # Power smoothing, power/workload policies and power state groups.
@@ -835,6 +845,10 @@ patterns = [
     "NvidiaPolicy.*.*",
     "NvidiaPolicyCollection.*.*",
 ]
+action_patterns = [
+    "NvidiaPowerSmoothing.*",
+    "NvidiaWorkloadPower.*",
+]
 
 [[oem-features]]
 # System and system-configuration profiles.
@@ -854,6 +868,10 @@ patterns = [
     "NvidiaSystemProfileFile.*.*",
     "NvidiaSystemConfigProfile.*.*",
     "NvidiaSystemConfigProfileStatus.*.*",
+]
+action_patterns = [
+    "NvidiaSystemProfile.*",
+    "NvidiaSystemConfigProfile.*",
 ]
 
 [[oem-features]]

--- a/redfish/features.toml
+++ b/redfish/features.toml
@@ -498,6 +498,7 @@ patterns = [
     "NvidiaCable.*.*",
     "NvidiaPCIeSlots.*.*",
 ]
+action_patterns = ["NvidiaChassis.*"]
 
 [[oem-features]]
 # NVIDIA manager, power-compliance manager and managed-entity inventory..

--- a/redfish/src/chassis/item.rs
+++ b/redfish/src/chassis/item.rs
@@ -59,6 +59,8 @@ use crate::log_service::LogService;
 use crate::oem::liteon;
 #[cfg(feature = "oem-nvidia")]
 use crate::oem::nvidia::NvidiaCbcChassis;
+#[cfg(feature = "oem-nvidia")]
+use crate::oem::nvidia::NvidiaChassisActions;
 #[cfg(feature = "pcie-devices")]
 use crate::pcie_device::PcieDeviceCollection;
 #[cfg(feature = "sensors")]
@@ -472,6 +474,23 @@ impl<B: Bmc> Chassis<B> {
             .map(NvidiaCbcChassis::new)
             .transpose()
             .map(|v| v.and_then(identity))
+    }
+
+    /// Get the NVIDIA OEM actions advertised by this chassis.
+    ///
+    /// Returns `Ok(None)` when the chassis has no OEM actions object.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if NVIDIA OEM actions cannot be parsed.
+    #[cfg(feature = "oem-nvidia")]
+    pub fn oem_nvidia_actions(&self) -> Result<Option<NvidiaChassisActions<B>>, Error<B>> {
+        self.data
+            .actions
+            .as_ref()
+            .and_then(|actions| actions.oem.as_ref())
+            .map(|actions| NvidiaChassisActions::new(&self.bmc, actions))
+            .transpose()
     }
 }
 

--- a/redfish/src/manager/item.rs
+++ b/redfish/src/manager/item.rs
@@ -148,7 +148,7 @@ impl<B: Bmc> Manager<B> {
         }
 
         actions
-            .reset_to_defaults(self.bmc.as_ref(), Some(reset_type))
+            .reset_to_defaults(self.bmc.as_ref(), reset_type)
             .await
             .map_err(Error::Bmc)
     }

--- a/redfish/src/oem/nvidia/chassis_actions.rs
+++ b/redfish/src/oem/nvidia/chassis_actions.rs
@@ -21,6 +21,7 @@ use crate::Error;
 use crate::NvBmc;
 use nv_redfish_core::Bmc;
 use nv_redfish_core::ModificationResponse;
+use serde::Deserialize as _;
 use std::sync::Arc;
 
 pub use crate::oem::nvidia::schema::nvidia_chassis::NvidiaChassisResetType;
@@ -35,8 +36,8 @@ pub struct NvidiaChassisActions<B: Bmc> {
 
 impl<B: Bmc> NvidiaChassisActions<B> {
     pub(crate) fn new(bmc: &NvBmc<B>, actions: &ChassisOemActionsSchema) -> Result<Self, Error<B>> {
-        let data =
-            serde_json::from_value(actions.additional_properties.clone()).map_err(Error::Json)?;
+        let data = NvidiaChassisActionsSchema::deserialize(&actions.additional_properties)
+            .map_err(Error::Json)?;
         Ok(Self {
             bmc: bmc.clone(),
             data: Arc::new(data),

--- a/redfish/src/oem/nvidia/chassis_actions.rs
+++ b/redfish/src/oem/nvidia/chassis_actions.rs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Support NVIDIA Chassis OEM actions.
+
+use crate::oem::nvidia::schema::chassis::OemActions as NvidiaChassisActionsSchema;
+use crate::schema::chassis::OemActions as ChassisOemActionsSchema;
+use crate::Error;
+use crate::NvBmc;
+use nv_redfish_core::Bmc;
+use nv_redfish_core::ModificationResponse;
+use std::sync::Arc;
+
+pub use crate::oem::nvidia::schema::nvidia_chassis::NvidiaChassisResetType;
+
+/// NVIDIA actions advertised by a Chassis resource.
+///
+/// The handle owns the BMC connection used to invoke its actions.
+pub struct NvidiaChassisActions<B: Bmc> {
+    bmc: NvBmc<B>,
+    data: Arc<NvidiaChassisActionsSchema>,
+}
+
+impl<B: Bmc> NvidiaChassisActions<B> {
+    pub(crate) fn new(bmc: &NvBmc<B>, actions: &ChassisOemActionsSchema) -> Result<Self, Error<B>> {
+        let data =
+            serde_json::from_value(actions.additional_properties.clone()).map_err(Error::Json)?;
+        Ok(Self {
+            bmc: bmc.clone(),
+            data: Arc::new(data),
+        })
+    }
+
+    /// Reset this chassis or its DPU with an NVIDIA reset type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the chassis does not advertise the NVIDIA `Reset`
+    /// action or if invoking the action fails.
+    pub async fn reset(
+        &self,
+        reset_type: Option<NvidiaChassisResetType>,
+    ) -> Result<ModificationResponse<()>, Error<B>>
+    where
+        B::Error: nv_redfish_core::ActionError,
+    {
+        if self.data.reset.is_none() {
+            return Err(Error::ActionNotAvailable);
+        }
+
+        self.data
+            .reset(self.bmc.as_ref(), reset_type)
+            .await
+            .map_err(Error::Bmc)
+    }
+
+    /// Get the raw NVIDIA Chassis OEM actions schema.
+    #[must_use]
+    pub fn raw(&self) -> Arc<NvidiaChassisActionsSchema> {
+        self.data.clone()
+    }
+}

--- a/redfish/src/oem/nvidia/chassis_actions.rs
+++ b/redfish/src/oem/nvidia/chassis_actions.rs
@@ -51,7 +51,7 @@ impl<B: Bmc> NvidiaChassisActions<B> {
     /// action or if invoking the action fails.
     pub async fn reset(
         &self,
-        reset_type: Option<NvidiaChassisResetType>,
+        reset_type: NvidiaChassisResetType,
     ) -> Result<ModificationResponse<()>, Error<B>>
     where
         B::Error: nv_redfish_core::ActionError,

--- a/redfish/src/oem/nvidia/mod.rs
+++ b/redfish/src/oem/nvidia/mod.rs
@@ -44,6 +44,9 @@ pub const OEM_KEY: &str = "Nvidia";
 #[cfg(feature = "chassis")]
 pub mod cbc_chassis;
 
+#[cfg(feature = "chassis")]
+pub mod chassis_actions;
+
 #[cfg(feature = "computer-systems")]
 pub mod computer_system;
 
@@ -53,6 +56,14 @@ pub mod processor_metrics;
 #[cfg(feature = "chassis")]
 #[doc(inline)]
 pub use cbc_chassis::NvidiaCbcChassis;
+
+#[cfg(feature = "chassis")]
+#[doc(inline)]
+pub use chassis_actions::NvidiaChassisActions;
+
+#[cfg(feature = "chassis")]
+#[doc(inline)]
+pub use chassis_actions::NvidiaChassisResetType;
 
 #[cfg(feature = "computer-systems")]
 #[doc(inline)]

--- a/redfish/src/update_service/mod.rs
+++ b/redfish/src/update_service/mod.rs
@@ -227,7 +227,7 @@ impl<B: Bmc> UpdateService<B> {
             .simple_update(
                 self.bmc.as_ref(),
                 &UpdateServiceSimpleUpdateAction {
-                    image_uri: Some(image_uri),
+                    image_uri,
                     transfer_protocol,
                     targets,
                     username,

--- a/tests/schemas/base/schema.xml
+++ b/tests/schemas/base/schema.xml
@@ -208,9 +208,9 @@
         <Parameter Name="RequiredNullableCollection" Type="Collection(Edm.String)" Nullable="true">
           <Annotation Term="Redfish.Required"/>
         </Parameter>
-        <Parameter Name="OptionalValue" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="OptionalValue" Type="Edm.String"/>
         <Parameter Name="OptionalNullableValue" Type="Edm.String" Nullable="true"/>
-        <Parameter Name="OptionalCollection" Type="Collection(Edm.String)" Nullable="false"/>
+        <Parameter Name="OptionalCollection" Type="Collection(Edm.String)"/>
         <Parameter Name="OptionalNullableCollection" Type="Collection(Edm.String)" Nullable="true"/>
         <Parameter Name="OptionalNullableEntity" Type="ServiceRoot.v1_0_0.TestRequiredService" Nullable="true"/>
       </Action>

--- a/tests/tests/test-chassis-oem-nvidia.rs
+++ b/tests/tests/test-chassis-oem-nvidia.rs
@@ -126,9 +126,7 @@ async fn oem_nvidia_reset_invokes_advertised_action() -> Result<(), Box<dyn StdE
 
     let actions = chassis.oem_nvidia_actions()?.unwrap();
     assert!(matches!(
-        actions
-            .reset(Some(NvidiaChassisResetType::ForceDpuReset))
-            .await?,
+        actions.reset(NvidiaChassisResetType::ForceDpuReset).await?,
         ModificationResponse::Entity(())
     ));
 
@@ -163,9 +161,7 @@ async fn oem_nvidia_reset_returns_action_not_available_when_reset_is_absent(
 
     let actions = chassis.oem_nvidia_actions()?.unwrap();
     assert!(matches!(
-        actions
-            .reset(Some(NvidiaChassisResetType::ForceDpuReset))
-            .await,
+        actions.reset(NvidiaChassisResetType::ForceDpuReset).await,
         Err(nv_redfish::Error::ActionNotAvailable)
     ));
 

--- a/tests/tests/test-chassis-oem-nvidia.rs
+++ b/tests/tests/test-chassis-oem-nvidia.rs
@@ -12,11 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//! Integration tests for NVIDIA CBC chassis OEM extension.
+//! Integration tests for NVIDIA chassis OEM extensions.
 
 use nv_redfish::chassis::Chassis;
+use nv_redfish::oem::nvidia::NvidiaChassisResetType;
 use nv_redfish::ServiceRoot;
+use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataId;
+use nv_redfish_tests::expect_redfish_reset_action;
 use nv_redfish_tests::json_merge;
 use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
@@ -96,6 +99,75 @@ async fn oem_nvidia_cbc_wrong_odata_type_returns_not_available() -> Result<(), B
     let chassis = get_chassis(bmc.clone(), &ids, chassis).await?;
 
     assert!(chassis.oem_nvidia_cbc()?.is_none());
+
+    Ok(())
+}
+
+#[test]
+async fn oem_nvidia_reset_invokes_advertised_action() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = chassis_ids();
+    let action_target = format!("{}/Actions/Oem/NvidiaChassis.Reset", ids.chassis_id);
+    let chassis = chassis_member(
+        &ids,
+        json!({
+            "Actions": {
+                "Oem": {
+                    "#NvidiaChassis.Reset": {
+                        "target": &action_target
+                    }
+                }
+            }
+        }),
+    );
+    let chassis = get_chassis(bmc.clone(), &ids, chassis).await?;
+
+    expect_redfish_reset_action(&bmc, &action_target, Some("ForceDpuReset"));
+
+    let actions = chassis.oem_nvidia_actions()?.unwrap();
+    assert!(matches!(
+        actions
+            .reset(Some(NvidiaChassisResetType::ForceDpuReset))
+            .await?,
+        ModificationResponse::Entity(())
+    ));
+
+    Ok(())
+}
+
+#[test]
+async fn oem_nvidia_actions_missing_oem_returns_not_available() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = chassis_ids();
+    let chassis = get_chassis(bmc, &ids, chassis_member(&ids, json!({}))).await?;
+
+    assert!(chassis.oem_nvidia_actions()?.is_none());
+
+    Ok(())
+}
+
+#[test]
+async fn oem_nvidia_reset_returns_action_not_available_when_reset_is_absent(
+) -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = chassis_ids();
+    let chassis = chassis_member(
+        &ids,
+        json!({
+            "Actions": {
+                "Oem": {}
+            }
+        }),
+    );
+    let chassis = get_chassis(bmc, &ids, chassis).await?;
+
+    let actions = chassis.oem_nvidia_actions()?.unwrap();
+    assert!(matches!(
+        actions
+            .reset(Some(NvidiaChassisResetType::ForceDpuReset))
+            .await,
+        Err(nv_redfish::Error::ActionNotAvailable)
+    ));
 
     Ok(())
 }

--- a/tests/tests/tests-base-operations.rs
+++ b/tests/tests/tests-base-operations.rs
@@ -651,7 +651,7 @@ async fn action_method_test() -> Result<(), Error> {
 
     assert!(matches!(
         service_actions
-            .test_action(&bmc, Some(ActionType::Option1))
+            .test_action(&bmc, ActionType::Option1)
             .await
             .map_err(Error::Bmc)?,
         ModificationResponse::Entity(())


### PR DESCRIPTION
Redfish defines two ways to add OEM actions:

1. Bind an action to an OEM-specific entity type.
2. Bind an action to an `OemActions` extension type from the standard schema.

In the second case, the action’s binding type must be included in the CSDL compiler’s root set for the action to be compiled correctly.

This PR:

1. Adds the ability to opt in to OEM actions using `action_patterns`.
2. Adds the binding types of matching actions to the root set.
3. Exposes NVIDIA chassis OEM actions as the first user of this mechanism. 
4. Fixes CSDL compiler to follow standard related to action parameters: "The term Nullable="false" in a parameter shall indicate the parameter is required in the action request body."
