### PR TITLE
refactor(csdl-compiler): replace root/resolve document index with typed fields

### DIFF
--- a/csdl-compiler/examples/schema-compilation.rs
+++ b/csdl-compiler/examples/schema-compilation.rs
@@ -46,21 +46,26 @@ fn main() -> Result<(), Error> {
         println!(" {} <root service> <redfish-csdl-file> ...", args[0]);
         return Err(Error::ParameterNeeded);
     }
+
     let root_service = args[1].parse().map_err(Error::WrongRootService)?;
-    let schema_bundle =
-        args[2..]
-            .iter()
-            .try_fold(SchemaBundle::default(), |mut schema_bundle, fname| {
-                let mut file =
-                    std::fs::File::open(fname).map_err(|err| Error::Io(fname.clone(), err))?;
-                let mut content = String::new();
-                file.read_to_string(&mut content)
-                    .map_err(|err| Error::Io(fname.clone(), err))?;
-                schema_bundle
-                    .edmx_docs
-                    .push(Edmx::parse(&content).map_err(|e| Error::Edmx(fname.clone(), e))?);
-                Ok(schema_bundle)
-            })?;
+
+    let root_docs = args
+        .iter()
+        .skip(2)
+        .map(|fname| {
+            let mut file =
+                std::fs::File::open(fname).map_err(|err| Error::Io(fname.clone(), err))?;
+
+            let mut content = String::new();
+            file.read_to_string(&mut content)
+                .map_err(|err| Error::Io(fname.clone(), err))?;
+
+            Edmx::parse(&content).map_err(|e| Error::Edmx(fname.clone(), e))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let schema_bundle = SchemaBundle::new(root_docs, Vec::new());
+
     let compiled = schema_bundle
         .compile(
             &[root_service],

--- a/csdl-compiler/examples/schema-rust-gen.rs
+++ b/csdl-compiler/examples/schema-rust-gen.rs
@@ -45,21 +45,26 @@ fn main() -> Result<(), Error> {
         println!(" {} <root service> <redfish-csdl-file> ...", args[0]);
         return Err(Error::ParameterNeeded);
     }
+
     let root_service = args[1].parse().map_err(Error::WrongRootService)?;
-    let schema_bundle =
-        args[2..]
-            .iter()
-            .try_fold(SchemaBundle::default(), |mut schema_bundle, fname| {
-                let mut file =
-                    std::fs::File::open(fname).map_err(|err| Error::Io(fname.clone(), err))?;
-                let mut content = String::new();
-                file.read_to_string(&mut content)
-                    .map_err(|err| Error::Io(fname.clone(), err))?;
-                schema_bundle
-                    .edmx_docs
-                    .push(Edmx::parse(&content).map_err(|e| Error::Edmx(fname.clone(), e))?);
-                Ok(schema_bundle)
-            })?;
+
+    let root_docs = args
+        .iter()
+        .skip(2)
+        .map(|fname| {
+            let mut file =
+                std::fs::File::open(fname).map_err(|err| Error::Io(fname.clone(), err))?;
+
+            let mut content = String::new();
+            file.read_to_string(&mut content)
+                .map_err(|err| Error::Io(fname.clone(), err))?;
+
+            Edmx::parse(&content).map_err(|e| Error::Edmx(fname.clone(), e))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let schema_bundle = SchemaBundle::new(root_docs, Vec::new());
+
     let compiled = schema_bundle
         .compile(
             &[root_service],

--- a/csdl-compiler/src/commands.rs
+++ b/csdl-compiler/src/commands.rs
@@ -173,7 +173,9 @@ fn process_command_inner(
             if csdls.is_empty() {
                 return Err(Error::AtLeastOneCSDLFileNeeded);
             }
-            let schema_bundle = read_csdls(&[], csdls)?;
+
+            let schema_bundle = read_csdls(csdls, &[])?;
+
             let compiled = schema_bundle
                 .compile(
                     &[root_service],
@@ -245,24 +247,27 @@ fn process_command_inner(
 }
 
 fn read_csdls(root_csdls: &[String], resolve_csdls: &[String]) -> Result<SchemaBundle, Error> {
-    let csdls = root_csdls
-        .iter()
-        .chain(resolve_csdls.iter())
-        .collect::<Vec<_>>();
-    let edmx_docs = csdls
-        .iter()
-        .map(|fname| {
-            let mut file = File::open(fname).map_err(|err| Error::Io((*fname).clone(), err))?;
-            let mut content = String::new();
-            file.read_to_string(&mut content)
-                .map_err(|err| Error::Io((*fname).clone(), err))?;
-            Edmx::parse(&content).map_err(|e| Error::Edmx((*fname).clone(), e))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let parse_all = |fnames: &[String]| {
+        fnames
+            .iter()
+            .map(|fname| {
+                let mut file = File::open(fname).map_err(|err| Error::Io(fname.clone(), err))?;
+                let mut content = String::new();
+                file.read_to_string(&mut content)
+                    .map_err(|err| Error::Io(fname.clone(), err))?;
 
-    csdls
+                Edmx::parse(&content).map_err(|e| Error::Edmx(fname.clone(), e))
+            })
+            .collect::<Result<Vec<_>, _>>()
+    };
+
+    let root_docs = parse_all(root_csdls)?;
+    let resolve_docs = parse_all(resolve_csdls)?;
+
+    root_csdls
         .iter()
-        .zip(&edmx_docs)
+        .zip(&root_docs)
+        .chain(resolve_csdls.iter().zip(&resolve_docs))
         .flat_map(|(fname, edmx)| {
             edmx.data_services
                 .schemas
@@ -272,7 +277,7 @@ fn read_csdls(root_csdls: &[String], resolve_csdls: &[String]) -> Result<SchemaB
         .fold(
             BTreeMap::<String, Vec<String>>::new(),
             |mut map, (namespace, fname)| {
-                map.entry(namespace).or_default().push((*fname).clone());
+                map.entry(namespace).or_default().push(fname.clone());
                 map
             },
         )
@@ -282,12 +287,5 @@ fn read_csdls(root_csdls: &[String], resolve_csdls: &[String]) -> Result<SchemaB
             Err(Error::DuplicateNamespace(namespace, files))
         })?;
 
-    Ok(SchemaBundle {
-        edmx_docs,
-        root_set_threshold: if root_csdls.is_empty() {
-            None
-        } else {
-            Some(root_csdls.len())
-        },
-    })
+    Ok(SchemaBundle::new(root_docs, resolve_docs))
 }

--- a/csdl-compiler/src/compiler/mod.rs
+++ b/csdl-compiler/src/compiler/mod.rs
@@ -200,13 +200,17 @@ pub enum TypeClass {
 }
 
 /// Collection of EDMX documents compiled together to produce code.
-#[derive(Default)]
+///
+/// Root documents are compiled: their types, and for `compile_all` their
+/// actions, become part of the output. Resolve documents exist only so a
+/// root document can reference types defined elsewhere; those types are
+/// pulled in on demand but never treated as compilation roots themselves.
 pub struct SchemaBundle {
-    /// Parsed and validated EDMX documents.
-    pub edmx_docs: Vec<Edmx>,
-    /// If set, defines how many documents belong to the "root set"
-    /// (used by `compile_all`).
-    pub root_set_threshold: Option<usize>,
+    /// Parsed and validated root documents.
+    root_docs: Vec<Edmx>,
+
+    /// Parsed and validated resolve documents.
+    resolve_docs: Vec<Edmx>,
 }
 
 /// Set of types that need to be compiled.
@@ -217,6 +221,22 @@ pub struct RootSet<'a> {
 }
 
 impl SchemaBundle {
+    /// Build a bundle from root documents and, optionally, resolve
+    /// documents used only to resolve type references from the root
+    /// documents; resolve documents are never compiled themselves.
+    #[must_use]
+    pub const fn new(root_docs: Vec<Edmx>, resolve_docs: Vec<Edmx>) -> Self {
+        Self {
+            root_docs,
+            resolve_docs,
+        }
+    }
+
+    /// All documents, root and resolve, for type-reference resolution.
+    fn all_docs(&self) -> impl Iterator<Item = &Edmx> + Clone {
+        self.root_docs.iter().chain(&self.resolve_docs)
+    }
+
     /// Compile multiple schemas, resolving all type dependencies.
     ///
     /// The root set is defined by the specified singletons.
@@ -230,7 +250,7 @@ impl SchemaBundle {
         root_patterns: &EntityTypeFilter,
         config: Config,
     ) -> Result<Compiled<'_>, Error<'_>> {
-        let schema_index = SchemaIndex::build(&self.edmx_docs)?;
+        let schema_index = SchemaIndex::build(self.all_docs())?;
         let root_set = self.root_set_from_singletons(&schema_index, singletons, root_patterns)?;
         let ctx = Context {
             schema_index,
@@ -250,8 +270,9 @@ impl SchemaBundle {
     /// Returns a compile error if any type cannot be resolved.
     pub fn compile_all(&self, config: Config) -> Result<Compiled<'_>, Error<'_>> {
         let root_set = self.root_set_all(&config.action_filter);
+
         let ctx = Context {
-            schema_index: SchemaIndex::build(&self.edmx_docs)?,
+            schema_index: SchemaIndex::build(self.all_docs())?,
             config,
             root_set_entities: root_set.entity_types.iter().copied().collect(),
         };
@@ -270,7 +291,7 @@ impl SchemaBundle {
         // If a singleton matches the requested set, collect its most recent
         // descendant type into the root set.
         let entity_types = self
-            .edmx_docs
+            .root_docs
             .iter()
             .flat_map(|edmx| {
                 edmx.data_services.schemas.iter().flat_map(|s| {
@@ -295,7 +316,7 @@ impl SchemaBundle {
                         })
                 })
             })
-            .chain(self.edmx_docs.iter().flat_map(|edmx| {
+            .chain(self.root_docs.iter().flat_map(|edmx| {
                 edmx.data_services
                     .schemas
                     .iter()
@@ -317,9 +338,8 @@ impl SchemaBundle {
             .collect::<Result<Vec<_>, _>>()?;
 
         let complex_types = self
-            .edmx_docs
+            .root_docs
             .iter()
-            .take(self.root_set_threshold.unwrap_or(self.edmx_docs.len()))
             .flat_map(|edmx| {
                 edmx.data_services.schemas.iter().flat_map(|s| {
                     s.types.values().filter_map(move |t| {
@@ -346,9 +366,8 @@ impl SchemaBundle {
 
     fn root_set_all(&self, action_filter: &ActionFilter) -> RootSet<'_> {
         let mut entity_types: Vec<_> = self
-            .edmx_docs
+            .root_docs
             .iter()
-            .take(self.root_set_threshold.unwrap_or(self.edmx_docs.len()))
             .flat_map(|edmx| {
                 edmx.data_services
                     .schemas
@@ -362,10 +381,10 @@ impl SchemaBundle {
                     .collect::<Vec<_>>()
             })
             .collect();
+
         let mut complex_types: Vec<_> = self
-            .edmx_docs
+            .root_docs
             .iter()
-            .take(self.root_set_threshold.unwrap_or(self.edmx_docs.len()))
             .flat_map(|edmx| {
                 edmx.data_services
                     .schemas
@@ -389,25 +408,23 @@ impl SchemaBundle {
         // A selected action is a compilation root, so its binding type is a
         // root as well. This is primarily needed by OEM actions bound to a
         // standard OemActions type supplied in a resolution-only document.
-        if let Some(root_set_threshold) = self.root_set_threshold {
-            complex_types.extend(
-                self.edmx_docs
-                    .iter()
-                    .take(root_set_threshold)
-                    .flat_map(|edmx| edmx.data_services.schemas.iter())
-                    .flat_map(|schema| {
-                        schema
-                            .actions
-                            .iter()
-                            .filter(move |action| {
-                                action.is_bound.into_inner()
-                                    && Self::action_matches_filter(schema, action, action_filter)
-                            })
-                            .filter_map(|action| action.parameters.first())
-                            .map(|binding| QualifiedName::from(binding.ptype.qualified_type_name()))
-                    }),
-            );
-        }
+        complex_types.extend(
+            self.root_docs
+                .iter()
+                .flat_map(|edmx| edmx.data_services.schemas.iter())
+                .flat_map(|schema| {
+                    schema
+                        .actions
+                        .iter()
+                        .filter(move |action| {
+                            action.is_bound.into_inner()
+                                && Self::action_matches_filter(schema, action, action_filter)
+                        })
+                        .filter_map(|action| action.parameters.first())
+                        .map(|binding| QualifiedName::from(binding.ptype.qualified_type_name()))
+                }),
+        );
+
         // Schemas store types in hash maps, and iteration order must not
         // decide compile order: which member of a reference cycle sees
         // the provisional type info — and with it generated output —
@@ -455,18 +472,17 @@ impl SchemaBundle {
         let compiled = EntityType::ensure(collection_name, ctx, &stack)?;
         let stack = stack.merge(compiled);
 
-        // Compile actions for all extracted types
-        self.edmx_docs
+        // Compile actions for all root-document types
+        self.root_docs
             .iter()
-            .enumerate()
-            .try_fold(stack, |stack, (document_index, edmx)| {
+            .try_fold(stack, |stack, edmx| {
                 let cstack = stack.new_frame();
                 let compiled = edmx
                     .data_services
                     .schemas
                     .iter()
                     .try_fold(cstack, |stack, s| {
-                        self.compile_schema_actions(document_index, s, ctx, stack.new_frame())
+                        Self::compile_schema_actions(s, ctx, stack.new_frame())
                             .map(|v| stack.merge(v))
                     })?
                     .done();
@@ -481,19 +497,13 @@ impl SchemaBundle {
     }
 
     fn compile_schema_actions<'a>(
-        &'a self,
-        document_index: usize,
         s: &'a Schema,
         ctx: &Context<'a>,
         stack: Stack<'a, '_>,
     ) -> Result<Compiled<'a>, Error<'a>> {
         s.actions
             .iter()
-            .filter(|action| {
-                self.root_set_threshold
-                    .is_none_or(|threshold| document_index < threshold)
-                    && Self::action_matches_filter(s, action, &ctx.config.action_filter)
-            })
+            .filter(|action| Self::action_matches_filter(s, action, &ctx.config.action_filter))
             .try_fold(stack, |stack, action| {
                 let compiled =
                     action::compile_action(action, Namespace::new(&s.namespace), ctx, &stack)
@@ -601,10 +611,11 @@ mod test {
                </Schema>
              </edmx:DataServices>
            </edmx:Edmx>"#;
-        let bundle = SchemaBundle {
-            edmx_docs: vec![Edmx::parse(schema).expect("entity cycle schema must be valid")],
-            root_set_threshold: None,
-        };
+
+        let bundle = SchemaBundle::new(
+            vec![Edmx::parse(schema).expect("entity cycle schema must be valid")],
+            Vec::new(),
+        );
 
         let result = bundle.compile_all(Config::default());
         assert!(
@@ -636,10 +647,11 @@ mod test {
              </edmx:DataServices>
            </edmx:Edmx>"#
         );
-        SchemaBundle {
-            edmx_docs: vec![Edmx::parse(&schema).expect("fixture schema must be valid")],
-            root_set_threshold: None,
-        }
+
+        SchemaBundle::new(
+            vec![Edmx::parse(&schema).expect("fixture schema must be valid")],
+            Vec::new(),
+        )
     }
 
     fn has_complex_type(compiled: &Compiled<'_>, name: &str) -> bool {
@@ -848,10 +860,9 @@ mod test {
                </Schema>
              </edmx:DataServices>
            </edmx:Edmx>"#;
-        let bundle = SchemaBundle {
-            edmx_docs: vec![Edmx::parse(schema).unwrap()],
-            root_set_threshold: None,
-        };
+
+        let bundle = SchemaBundle::new(vec![Edmx::parse(schema).unwrap()], Vec::new());
+
         let compiled = bundle
             .compile(
                 &["Service".parse().unwrap()],

--- a/csdl-compiler/src/compiler/schema_index.rs
+++ b/csdl-compiler/src/compiler/schema_index.rs
@@ -41,9 +41,10 @@ impl<'a> SchemaIndex<'a> {
     /// # Errors
     ///
     /// Returns an error if entity or complex type inheritance contains a cycle.
-    pub fn build(edmx_docs: &'a [Edmx]) -> Result<Self, Error<'a>> {
+    pub fn build(edmx_docs: impl IntoIterator<Item = &'a Edmx> + Clone) -> Result<Self, Error<'a>> {
         let index = edmx_docs
-            .iter()
+            .clone()
+            .into_iter()
             .flat_map(|v| {
                 v.data_services
                     .schemas
@@ -51,7 +52,8 @@ impl<'a> SchemaIndex<'a> {
                     .map(|s| (Namespace::new(&s.namespace), s))
             })
             .collect();
-        let (child_map, base_map) = edmx_docs.iter().fold(
+
+        let (child_map, base_map) = edmx_docs.into_iter().fold(
             (
                 HashMap::<QualifiedName<'a>, Vec<QualifiedName<'a>>>::new(),
                 HashMap::<QualifiedName<'a>, QualifiedName<'a>>::new(),

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -261,10 +261,10 @@ mod tests {
           </edmx:DataServices>
         </edmx:Edmx>"#;
 
-        let bundle = SchemaBundle {
-            edmx_docs: vec![Edmx::parse(schema).map_err(|error| error.to_string())?],
-            root_set_threshold: None,
-        };
+        let bundle = SchemaBundle::new(
+            vec![Edmx::parse(schema).map_err(|error| error.to_string())?],
+            Vec::new(),
+        );
 
         let serialize_and_deserialize = quote! {
             #[derive(Serialize)]
@@ -341,13 +341,11 @@ mod tests {
           </edmx:DataServices>
         </edmx:Edmx>"#;
 
-        let bundle = SchemaBundle {
-            edmx_docs: vec![
-                Edmx::parse(oem_schema).map_err(|error| error.to_string())?,
-                Edmx::parse(resolve_schema).map_err(|error| error.to_string())?,
-            ],
-            root_set_threshold: Some(1),
-        };
+        let bundle = SchemaBundle::new(
+            vec![Edmx::parse(oem_schema).map_err(|error| error.to_string())?],
+            vec![Edmx::parse(resolve_schema).map_err(|error| error.to_string())?],
+        );
+
         let compiled_without_action_patterns = bundle
             .compile_all(CompilerConfig {
                 action_filter: ActionFilter::new_restrictive(Vec::new()),

--- a/csdl-compiler/src/query.rs
+++ b/csdl-compiler/src/query.rs
@@ -341,10 +341,11 @@ mod test {
             </Schema>
           </edmx:DataServices>
         </edmx:Edmx>"#;
-        SchemaBundle {
-            edmx_docs: vec![Edmx::parse(schema).expect("query test schema must be valid")],
-            root_set_threshold: None,
-        }
+
+        SchemaBundle::new(
+            vec![Edmx::parse(schema).expect("query test schema must be valid")],
+            Vec::new(),
+        )
     }
 
     #[test]


### PR DESCRIPTION
`SchemaBundle` tracked compilation roots via a `root_set_threshold` index into one document list, enforced only by convention. Split into root_docs/resolve_docs fields so an inconsistent bundle can no longer be constructed. Also fixed the one call site (Commands::Compile) that relied on the old index's implicit "empty means everything is root" behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved schema compilation by distinguishing primary schema files from resolve-only files.
  * Schemas can now be loaded and resolved together while generated types and actions are compiled only from primary documents.
  * Improved schema indexing and dependency resolution across related schema files.
  * Preserved filename-aware error reporting for file loading and parsing failures.
* **Tests**
  * Updated compiler and generator tests for the revised schema bundle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->