### PR TITLE
fix(bmc-http): replace the barging request-limit semaphore with a FIFO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ keywords = ["rust", "redfish", "bmc"]
 categories = ["hardware-support"]
 
 [workspace.dependencies]
-async-lock = { version = "3.4" }
 clap = { version = "4.5" }
 clap_derive = { version = "4.5" }
 sse-stream = { version = "0.2.4" }
@@ -69,7 +68,7 @@ nv-redfish-schema = { version = "0.1", path = "./schema" }
 toml = { version = "0.9", default-features = false }
 
 # Dev
-tokio = "1"
+tokio = "1.30"
 gungraun = "0.19.3"
 tokio-test = "0.4"
 # had to use 0.6.4 since it works with 2018 edition (2024 needs extra work) 

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -14,12 +14,11 @@ documentation = "https://docs.rs/nv-redfish-bmc-http"
 default = ["reqwest"]
 
 # HTTP client implementations with reqwest
-reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:sse-stream", "dep:tokio-util", "dep:tokio", "dep:bytes"]
-http-extras = ["dep:async-lock"]
+reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:sse-stream", "dep:tokio-util", "dep:tokio", "tokio/time", "dep:bytes"]
+http-extras = ["dep:tokio", "tokio/sync"]
 update-service-deprecated = ["nv-redfish-core/update-service-deprecated"]
 
 [dependencies]
-async-lock = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true, optional = true }
@@ -36,7 +35,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true, optional = true }
 sse-stream = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, features = ["time"] }
+tokio = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true, features = ["compat", "io"] }
 url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }

--- a/bmc-http/src/concurrency.rs
+++ b/bmc-http/src/concurrency.rs
@@ -14,8 +14,9 @@ use nv_redfish_core::{
     MultipartUpdateRequest, ODataETag, ODataId, SessionCreateResponse, UploadReader,
 };
 
-use async_lock::Semaphore;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+use tokio::sync::SemaphorePermit;
 
 /// Limits the number of concurrent operations entering an inner BMC.
 ///
@@ -26,8 +27,9 @@ use serde::{Deserialize, Serialize};
 /// A permit covers the complete inner [`Bmc`] operation, including transport
 /// retries. Stream operations release their permit after connection
 /// establishment, so the returned stream does not consume capacity.
-/// Capacity waits are asynchronous, and canceling a waiting operation does not
-/// consume a permit.
+/// Capacity waits are asynchronous and served in arrival order — a released
+/// permit goes to the longest waiter, so no operation starves under
+/// sustained load. Canceling a waiting operation does not consume a permit.
 ///
 /// # Examples
 ///
@@ -55,11 +57,28 @@ pub struct ConcurrencyLimitedBmc<B> {
 
 impl<B> ConcurrencyLimitedBmc<B> {
     pub(crate) const fn new(inner: B, limit: NonZeroUsize) -> Self {
+        // `const_new` asserts `permits <= MAX_PERMITS`; clamping keeps every
+        // `NonZeroUsize` valid, as it was with the previous semaphore.
+        let permits = if limit.get() > Semaphore::MAX_PERMITS {
+            Semaphore::MAX_PERMITS
+        } else {
+            limit.get()
+        };
         Self {
             inner,
-            semaphore: Semaphore::new(limit.get()),
+            semaphore: Semaphore::const_new(permits),
         }
     }
+}
+
+/// Waits for a permit. Acquisition is fair (FIFO) and only ever waits:
+/// the semaphore is never closed. A free function borrowing only the
+/// semaphore, so the future is `Send` without bounding the wrapped `B`.
+async fn permit(semaphore: &Semaphore) -> SemaphorePermit<'_> {
+    semaphore
+        .acquire()
+        .await
+        .expect("the semaphore is never closed")
 }
 
 impl<C: HttpClient> HttpBmc<C>
@@ -69,7 +88,8 @@ where
     /// Configures the maximum number of concurrent Redfish operations.
     ///
     /// The limit covers complete logical operations, including transport
-    /// retries. Without this method, the BMC remains unlimited.
+    /// retries. Without this method, the BMC remains unlimited. Limits above
+    /// `usize::MAX >> 3` are treated as that value.
     #[must_use]
     pub const fn with_request_concurrency_limit(
         self,
@@ -101,7 +121,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         id: &ODataId,
         query: ExpandQuery,
     ) -> Result<Arc<T>, Self::Error> {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.expand(id, query).await
     }
 
@@ -109,7 +129,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         &self,
         id: &ODataId,
     ) -> Result<Arc<T>, Self::Error> {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.get(id).await
     }
 
@@ -118,7 +138,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         id: &ODataId,
         query: FilterQuery,
     ) -> Result<Arc<T>, Self::Error> {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.filter(id, query).await
     }
 
@@ -131,7 +151,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         V: Send + Sync + Serialize,
         R: Send + Sync + for<'de> Deserialize<'de>,
     {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.create(id, query).await
     }
 
@@ -144,7 +164,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         V: Send + Sync + Serialize,
         R: Send + Sync + for<'de> Deserialize<'de>,
     {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.create_session(id, query).await
     }
 
@@ -158,7 +178,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         V: Sync + Send + Serialize,
         R: Send + Sync + Sized + for<'de> Deserialize<'de>,
     {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.update(id, etag, update).await
     }
 
@@ -166,7 +186,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
     where
         R: EntityTypeRef + for<'de> Deserialize<'de>,
     {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.delete(id).await
     }
 
@@ -179,7 +199,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         T: Send + Sync + Serialize,
         R: Send + Sync + Sized + for<'de> Deserialize<'de>,
     {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.action(action, params).await
     }
 
@@ -193,7 +213,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         R: Send + Sync + for<'de> Deserialize<'de>,
         V: Send + Sync + Serialize,
     {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.multipart_update(uri, request).await
     }
 
@@ -207,7 +227,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
         U: UploadReader,
         R: Send + Sync + for<'de> Deserialize<'de>,
     {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.http_push_uri_update(uri, request).await
     }
 
@@ -215,7 +235,7 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
     where
         T: Sized + for<'de> Deserialize<'de> + Send + 'static,
     {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = permit(&self.semaphore).await;
         self.inner.stream(uri).await
     }
 }

--- a/bmc-http/tests/request_concurrency_tests.rs
+++ b/bmc-http/tests/request_concurrency_tests.rs
@@ -494,6 +494,48 @@ mod tests {
     }
 
     #[test]
+    fn a_released_permit_goes_to_the_longest_waiter_not_a_barger() {
+        let (client, mut transport) = controlled_client();
+        let bmc = create_bmc(client, NonZeroUsize::MIN, 0);
+        let holder_id = ODataId::from("/holder".to_owned());
+        let waiter_id = ODataId::from("/waiter".to_owned());
+        let barger_id = ODataId::from("/barger".to_owned());
+
+        // The holder takes the only permit; then two operations queue in
+        // arrival order.
+        let mut holder = tokio_test::task::spawn(bmc.get::<TestResource>(&holder_id));
+        assert_pending!(holder.poll());
+        let holder_attempt = transport.next_attempt();
+
+        let mut waiter = tokio_test::task::spawn(bmc.get::<TestResource>(&waiter_id));
+        assert_pending!(waiter.poll());
+        let mut barger = tokio_test::task::spawn(bmc.get::<TestResource>(&barger_id));
+        assert_pending!(barger.poll());
+        transport.assert_no_attempt();
+
+        // Release the permit, then poll the barger FIRST: arrival order
+        // must beat poll order, or a hot caller starves the queue.
+        respond(holder_attempt, TestResponse::Resource(None));
+        assert_ready_ok!(holder.poll());
+        assert_pending!(barger.poll());
+        transport.assert_no_attempt();
+
+        assert!(waiter.is_woken());
+        assert_pending!(waiter.poll());
+        let waiter_attempt = transport.next_attempt();
+        assert_eq!(waiter_attempt.path, "/waiter");
+        respond(waiter_attempt, TestResponse::Resource(None));
+        assert_ready_ok!(waiter.poll());
+
+        assert!(barger.is_woken());
+        assert_pending!(barger.poll());
+        let barger_attempt = transport.next_attempt();
+        assert_eq!(barger_attempt.path, "/barger");
+        respond(barger_attempt, TestResponse::Resource(None));
+        assert_ready_ok!(barger.poll());
+    }
+
+    #[test]
     fn limit_two_allows_two_operations_and_blocks_a_third() {
         let (client, mut transport) = controlled_client();
         let limit = NonZeroUsize::new(2).expect("test limit must be non-zero");


### PR DESCRIPTION
Fix issue from async-lock semaphore which would steal fresh work and starve waiters under load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request concurrency handling to ensure waiting requests receive permits in first-in, first-out order.
  * Prevented concurrency limits from exceeding supported bounds.
* **Tests**
  * Added coverage verifying fair permit assignment, including cases where later requests are processed before earlier waiters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->