### PR TITLE
chore: update rust to 1.95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.90.0"
+          toolchain: "1.95.0"
       - run: make ci
 
   bench-regression:
@@ -38,7 +38,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.90.0"
+          toolchain: "1.95.0"
 
       - name: Install valgrind
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: "1.90.0"
+        toolchain: "1.95.0"
 
     - name: Publish Crates
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ repository = "https://github.com/dsx-ai-factory/nv-redfish"
 description = "Rust implementation of Redfish API for BMC management"
 readme = "README.md"
 edition = "2018"
+rust-version = "1.95"
 keywords = ["rust", "redfish", "bmc"]
 categories = ["hardware-support"]
 

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish-bmc-http"

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -466,12 +466,12 @@ impl Default for SseOptions {
 impl Default for ClientParams {
     fn default() -> Self {
         Self {
-            timeout: Some(Duration::from_secs(120)),
+            timeout: Some(Duration::from_mins(2)),
             connect_timeout: Some(Duration::from_secs(5)),
             user_agent: Some("nv-redfish/v1".to_string()),
             accept_invalid_certs: false,
             max_redirects: Some(10),
-            tcp_keepalive: Some(Duration::from_secs(60)),
+            tcp_keepalive: Some(Duration::from_mins(1)),
             pool_idle_timeout: Some(Duration::from_secs(90)),
             pool_max_idle_per_host: Some(1),
             default_headers: None,

--- a/bmc-mock/Cargo.toml
+++ b/bmc-mock/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish-bmc-mock"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish-core"

--- a/csdl-compiler/Cargo.toml
+++ b/csdl-compiler/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish-csdl-compiler"

--- a/dispatcher/Cargo.toml
+++ b/dispatcher/Cargo.toml
@@ -27,6 +27,7 @@ exclude = [
     "tests/**",
 ]
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish-dispatcher"

--- a/dispatcher/sim/Cargo.toml
+++ b/dispatcher/sim/Cargo.toml
@@ -22,6 +22,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -1018,7 +1018,7 @@ mod tests {
         let clock = ManualClock::new();
         let now = clock.now();
         let deadline = now + Duration::from_secs(1);
-        let interval = Duration::from_secs(60);
+        let interval = Duration::from_mins(1);
 
         let mut root = TestRoot::new();
 
@@ -1068,7 +1068,7 @@ mod tests {
         let clock = ManualClock::new();
         let now = clock.now();
         let deadline = now + Duration::from_secs(1);
-        let interval = Duration::from_secs(60);
+        let interval = Duration::from_mins(1);
         let mut root = TestRoot::new();
 
         root.add_child(PeriodicLeaf::new(now, interval, || {

--- a/examples/event-stream-console/Cargo.toml
+++ b/examples/event-stream-console/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/explore-with-dummy-bmc/Cargo.toml
+++ b/examples/explore-with-dummy-bmc/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/explore-with-reqwest-bmc/Cargo.toml
+++ b/examples/explore-with-reqwest-bmc/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/metrics-oem-nvidia/Cargo.toml
+++ b/examples/metrics-oem-nvidia/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/readme-minimal/Cargo.toml
+++ b/examples/readme-minimal/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/redfish-oem-contoso/Cargo.toml
+++ b/examples/redfish-oem-contoso/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/redfish-std/Cargo.toml
+++ b/examples/redfish-std/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/service-root-parser/Cargo.toml
+++ b/examples/service-root-parser/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/session-token/Cargo.toml
+++ b/examples/session-token/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/task-service/Cargo.toml
+++ b/examples/task-service/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/examples/update-multipart/Cargo.toml
+++ b/examples/update-multipart/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -6,6 +6,7 @@ description.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.95.0"
 profile = "minimal"
 components = ["clippy", "rustfmt", "rust-analyzer"]

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish-schema"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 


### PR DESCRIPTION
Breaking

Update minimal rust version to 1.95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project, continuous integration, benchmarking, and release tooling to use Rust 1.95.0.
  * Standardized Rust version requirements across workspace packages to improve build consistency and compatibility checks.
  * Updated time-duration definitions for request timeouts, TCP keepalive, and runtime tests while preserving existing timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->