### PR TITLE
feat(oem-liteon): expose CapacityWatts on LiteonPowerSupply

### DIFF
--- a/schema/oem/liteon/LiteonPowerSupply_v1.xml
+++ b/schema/oem/liteon/LiteonPowerSupply_v1.xml
@@ -18,13 +18,18 @@ limitations under the License.
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
   <edmx:DataServices>
     <!-- This is how LiteOn extended standard PowerSupply object with
-         PowerState field (it is absent in standard Redfish). -->
+         PowerState (absent in standard Redfish) and CapacityWatts (a
+         decimal string under a non-standard name, in place of the standard
+         numeric PowerCapacityWatts). Observed on PF-1333-7R firmware r1.3.8. -->
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LiteonPowerSupply">
       <EntityType Name="LiteonPowerSupply" BaseType="PowerSupply.v1_6_0.PowerSupply"/>
     </Schema>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LiteonPowerSupply.v1_0_0">
       <EntityType Name="LiteonPowerSupply" BaseType="LiteonPowerSupply.LiteonPowerSupply">
         <Property Name="PowerState" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="CapacityWatts" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
         </Property>
       </EntityType>

--- a/tests/tests/test-chassis-oem-liteon-power-supply.rs
+++ b/tests/tests/test-chassis-oem-liteon-power-supply.rs
@@ -61,6 +61,10 @@ async fn liteon_power_supply_links_happy_path() -> Result<(), Box<dyn StdError>>
     bmc.expect(Expect::get(&psu_id, psu_payload(&psu_id, "0", true)));
     let psu = links[0].fetch().await?;
     assert_eq!(psu.power_state, Some(true));
+    assert_eq!(
+        psu.capacity_watts.as_ref().map(|v| v.as_deref()),
+        Some(Some("5500"))
+    );
 
     Ok(())
 }
@@ -232,6 +236,7 @@ fn psu_payload(psu_id: &str, id: &str, power_state: bool) -> Value {
         "Manufacturer": "LITE-ON TECHNOLOGY CORP.",
         "Model": "SP-2552-1R",
         "PowerState": power_state,
+        "CapacityWatts": "5500",
         "Status": {
             "Health": "OK",
             "State": "Enabled"


### PR DESCRIPTION
Adds a quirk for LiteOn PF-1333-7R power shelves (firmware r1.3.8).

Adds PSU capacity as a decimal string under the non-standard CapacityWatts name instead of the standard numeric PowerCapacityWatts. Previously, the generic PowerSupply schema leaves capacity unset.

Add property to the LiteOn OEM PowerSupply schema so CapacityWatts is readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only capacity rating field to LiteOn power supply details.
  * Documented the power state and string-formatted capacity value.

* **Tests**
  * Updated power supply validation to confirm a reported capacity of 5500 watts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->