### PR TITLE
feat: SSE events carry last seen message

### DIFF
--- a/bmc-http/src/concurrency.rs
+++ b/bmc-http/src/concurrency.rs
@@ -9,6 +9,7 @@ use crate::{BmcCredentials, CacheableError, HttpBmc, HttpClient};
 use nv_redfish_core::query::ExpandQuery;
 #[cfg(feature = "update-service-deprecated")]
 use nv_redfish_core::HttpPushUriUpdateRequest;
+use nv_redfish_core::StreamEvent;
 use nv_redfish_core::{
     Action, Bmc, BoxTryStream, EntityTypeRef, Expandable, FilterQuery, ModificationResponse,
     MultipartUpdateRequest, ODataETag, ODataId, SessionCreateResponse, UploadReader,
@@ -237,5 +238,18 @@ impl<B: Bmc> Bmc for ConcurrencyLimitedBmc<B> {
     {
         let _permit = permit(&self.semaphore).await;
         self.inner.stream(uri).await
+    }
+
+    async fn stream_events<T>(
+        &self,
+        uri: &str,
+        last_event_id: Option<&str>,
+    ) -> Result<BoxTryStream<StreamEvent<T>, Self::Error>, Self::Error>
+    where
+        T: Sized + for<'de> Deserialize<'de> + Send + 'static,
+        B::Error: 'static,
+    {
+        let _permit = permit(&self.semaphore).await;
+        self.inner.stream_events(uri, last_event_id).await
     }
 }

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -59,6 +59,7 @@ use crate::cache::TypeErasedCarCache;
 
 use http::HeaderMap;
 use nv_redfish_core::query::ExpandQuery;
+use nv_redfish_core::without_event_ids;
 use nv_redfish_core::Action;
 use nv_redfish_core::Bmc;
 use nv_redfish_core::BoxTryStream;
@@ -69,6 +70,7 @@ use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataETag;
 use nv_redfish_core::ODataId;
 use nv_redfish_core::SessionCreateResponse;
+use nv_redfish_core::StreamEvent;
 use nv_redfish_core::UploadReader;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use url::Url;
@@ -194,6 +196,30 @@ pub trait HttpClient: Send + Sync {
         credentials: &BmcCredentials,
         custom_headers: &HeaderMap,
     ) -> impl Future<Output = Result<BoxTryStream<T, Self::Error>, Self::Error>> + Send;
+
+    /// Open an SSE stream whose events carry their ids, resuming after
+    /// `last_event_id` when one is given.
+    ///
+    /// The default forwards to [`HttpClient::sse`]: its events carry no id
+    /// and nothing is sent to resume from. A client that surfaces SSE ids
+    /// overrides it.
+    fn sse_events<T: Sized + for<'de> Deserialize<'de> + Send + 'static>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+        last_event_id: Option<&str>,
+    ) -> impl Future<Output = Result<BoxTryStream<StreamEvent<T>, Self::Error>, Self::Error>> + Send
+    where
+        Self::Error: 'static,
+    {
+        let _ = last_event_id;
+        async move {
+            self.sse::<T>(url, credentials, custom_headers)
+                .await
+                .map(without_event_ids)
+        }
+    }
 }
 
 /// HTTP-based BMC implementation that wraps an [`HttpClient`].
@@ -823,6 +849,30 @@ where
         let credentials = self.read_credentials();
         self.client
             .sse(endpoint_url, credentials.as_ref(), &self.custom_headers)
+            .await
+    }
+
+    async fn stream_events<T: Send + Sized + for<'de> Deserialize<'de> + 'static>(
+        &self,
+        uri: &str,
+        last_event_id: Option<&str>,
+    ) -> Result<BoxTryStream<StreamEvent<T>, Self::Error>, Self::Error>
+    where
+        C::Error: 'static,
+    {
+        let endpoint_url = self
+            .redfish_endpoint
+            .with_same_origin_uri_reference(UriReference(uri))
+            .map_err(C::Error::rejected_uri_reference)?;
+
+        let credentials = self.read_credentials();
+        self.client
+            .sse_events(
+                endpoint_url,
+                credentials.as_ref(),
+                &self.custom_headers,
+                last_event_id,
+            )
             .await
     }
 }

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -1313,11 +1313,16 @@ impl HttpClient for Client {
         custom_headers: &HeaderMap,
         last_event_id: Option<&str>,
     ) -> Result<BoxTryStream<StreamEvent<T>, Self::Error>, Self::Error> {
+        // An empty id is no id, as the SSE processing model has it: none is
+        // sent, and none is in effect until the server sets one. Otherwise
+        // the resume id stays in effect across the reconnection, so events
+        // the server sends without an `id` field still carry it.
+        let last_event_id = last_event_id.filter(|id| !id.is_empty());
         let frames = self
             .sse_frames(url, credentials, custom_headers, last_event_id)
             .await?;
         let events = frames
-            .scan(None, |last_event_id, frame| {
+            .scan(last_event_id.map(str::to_owned), |last_event_id, frame| {
                 ready(Some(event_to_item::<T>(last_event_id, frame)))
             })
             .filter_map(ready);

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -36,6 +36,7 @@ use bytes::Bytes;
 use futures_util::stream::unfold;
 use futures_util::Stream;
 use futures_util::StreamExt as _;
+use futures_util::TryStreamExt as _;
 use http::header;
 use http::HeaderMap;
 use nv_redfish_core::AsyncTask;
@@ -46,6 +47,7 @@ use nv_redfish_core::ODataETag;
 use nv_redfish_core::ODataId;
 use nv_redfish_core::OemMultipartPart;
 use nv_redfish_core::SessionCreateResponse;
+use nv_redfish_core::StreamEvent;
 use nv_redfish_core::UploadReader;
 #[cfg(feature = "update-service-deprecated")]
 use nv_redfish_core::UploadStream;
@@ -293,18 +295,45 @@ fn cap_event_bytes(
     })
 }
 
-/// Decode one SSE record into a typed item, or `None` for records without data
-/// (e.g. comments) so they are filtered out of the stream.
-fn event_to_item<T: DeserializeOwned>(
-    event: Result<sse_stream::Sse, sse_stream::Error>,
+/// The header a client sends to resume a stream after the last event it saw.
+const LAST_EVENT_ID: header::HeaderName = header::HeaderName::from_static("last-event-id");
+
+/// Decodes one SSE frame's `data` into an item. A frame without `data` is no
+/// item; one whose data fails to decode is an error item.
+fn decode_frame<T: DeserializeOwned>(
+    frame: Result<sse_stream::Sse, BmcError>,
 ) -> Option<Result<T, BmcError>> {
-    match event {
-        Err(err) => Some(Err(map_sse_error(err))),
+    match frame {
+        Err(err) => Some(Err(err)),
         Ok(sse) => sse.data.map(|data| {
             serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_str(&data))
                 .map_err(BmcError::JsonError)
         }),
     }
+}
+
+/// [`decode_frame`] with the last event id tracked across frames as the SSE
+/// processing model prescribes: a frame's `id` field sets it, an empty one
+/// clears it, one holding a NUL is ignored, and a frame without one leaves
+/// it, so the id on an item is the one to resume after it.
+fn event_to_item<T: DeserializeOwned>(
+    last_event_id: &mut Option<String>,
+    frame: Result<sse_stream::Sse, BmcError>,
+) -> Option<Result<StreamEvent<T>, BmcError>> {
+    if let Ok(sse) = &frame {
+        match &sse.id {
+            Some(id) if id.contains('\0') => {}
+            Some(id) if id.is_empty() => *last_event_id = None,
+            Some(id) => *last_event_id = Some(id.clone()),
+            None => {}
+        }
+    }
+    decode_frame::<T>(frame).map(|item| {
+        item.map(|data| StreamEvent {
+            last_event_id: last_event_id.clone(),
+            data,
+        })
+    })
 }
 
 /// Classifier deciding whether a response should be retried.
@@ -449,8 +478,10 @@ pub struct SseOptions {
     /// [`Client::sse`] aborts with [`BmcError::SseEventTooLarge`]. Guards against
     /// a server that never sends the SSE event terminator.
     pub max_event_bytes: usize,
-    /// Maximum idle time between SSE events before [`Client::sse`] aborts with
-    /// [`BmcError::SseIdleTimeout`]. `None` disables the check.
+    /// Maximum idle time between SSE frames before the stream aborts with
+    /// [`BmcError::SseIdleTimeout`]. A frame is an event, or one carrying
+    /// only an `id` or `event` field; comment heartbeats do not count.
+    /// `None` disables the check.
     pub idle_timeout: Option<Duration>,
 }
 
@@ -1258,20 +1289,75 @@ impl HttpClient for Client {
         self.handle_modification_response(response).await
     }
 
-    // The idle branch matches on `Option<Duration>` where both arms await
-    // distinct future types, which cannot be expressed as an `Option` combinator
-    // without boxing; `option_if_let_else`'s suggestion does not apply.
-    #[allow(clippy::option_if_let_else)]
     async fn sse<T: Send + Sized + for<'de> serde::Deserialize<'de>>(
         &self,
         url: Url,
         credentials: &BmcCredentials,
         custom_headers: &HeaderMap,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
-        let request = auth_headers(self.inner.get(url), credentials)
+        let frames = self
+            .sse_frames(url, credentials, custom_headers, None)
+            .await?;
+        // Decoded in an async block rather than `ready(..)`: the boxed
+        // stream's type must not mention `T`, which the trait leaves without
+        // a `'static` bound.
+        Ok(Box::pin(frames.filter_map(|frame| async move {
+            decode_frame::<T>(frame)
+        })))
+    }
+
+    async fn sse_events<T: Send + Sized + for<'de> serde::Deserialize<'de> + 'static>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+        last_event_id: Option<&str>,
+    ) -> Result<BoxTryStream<StreamEvent<T>, Self::Error>, Self::Error> {
+        let frames = self
+            .sse_frames(url, credentials, custom_headers, last_event_id)
+            .await?;
+        let events = frames
+            .scan(None, |last_event_id, frame| {
+                ready(Some(event_to_item::<T>(last_event_id, frame)))
+            })
+            .filter_map(ready);
+        Ok(Box::pin(events))
+    }
+}
+
+impl Client {
+    /// Opens the SSE request, `Last-Event-ID` set when resuming, and returns
+    /// its frames: decoded from a body capped at
+    /// [`SseOptions::max_event_bytes`] per event, ended after a fatal error,
+    /// and, when [`SseOptions::idle_timeout`] is set, failed when no frame
+    /// arrives within that window. The window is keyed on frames the server
+    /// sends, so comment heartbeats (which the decoder discards) do NOT reset
+    /// it; a server relying solely on comment heartbeats should not enable
+    /// the idle timeout.
+    // The idle branch matches on `Option<Duration>` where both arms await
+    // distinct future types, which cannot be expressed as an `Option`
+    // combinator without boxing; `option_if_let_else`'s suggestion does not
+    // apply.
+    #[allow(clippy::option_if_let_else)]
+    async fn sse_frames(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+        last_event_id: Option<&str>,
+    ) -> Result<BoxTryStream<sse_stream::Sse, BmcError>, BmcError> {
+        let mut request = auth_headers(self.inner.get(url), credentials)
             .headers(custom_headers.clone())
             .header(header::ACCEPT, "text/event-stream")
             .timeout(Duration::MAX);
+        if let Some(id) = last_event_id {
+            let value = header::HeaderValue::from_str(id).map_err(|_| {
+                BmcError::InvalidRequest(format!(
+                    "Last-Event-ID {id:?} cannot be sent as a header value"
+                ))
+            })?;
+            request = request.header(LAST_EVENT_ID, value);
+        }
 
         let response = self.send(request.build()?).await?;
 
@@ -1284,39 +1370,34 @@ impl HttpClient for Client {
         }
 
         let capped = cap_event_bytes(response.bytes_stream(), self.sse.max_event_bytes);
-        let events = sse_stream::SseStream::from_bytes_stream(capped)
-            .filter_map(|event| async move { event_to_item::<T>(event) });
+        let frames = sse_stream::SseStream::from_bytes_stream(capped).map_err(map_sse_error);
 
-        // Liveness bound: optionally abort if no event arrives within the idle
-        // window. It is keyed on decoded events, so comment heartbeats (which
-        // `sse_stream` discards) do NOT reset it; a server relying solely on
-        // comment heartbeats should not enable the idle timeout.
         let idle = self.sse.idle_timeout;
-        let guarded = unfold(
-            (Box::pin(events), false),
-            move |(mut events, done)| async move {
+        let bounded = unfold(
+            (Box::pin(frames), false),
+            move |(mut frames, done)| async move {
                 if done {
                     return None;
                 }
                 let next = match idle {
-                    Some(d) => match timeout(d, events.next()).await {
-                        Ok(item) => item,
+                    Some(d) => match timeout(d, frames.next()).await {
+                        Ok(frame) => frame,
                         Err(_) => Some(Err(BmcError::SseIdleTimeout { idle: d })),
                     },
-                    None => events.next().await,
+                    None => frames.next().await,
                 };
                 match next {
                     Some(Err(e)) => {
                         let terminal = e.is_stream_fatal();
-                        Some((Err(e), (events, terminal)))
+                        Some((Err(e), (frames, terminal)))
                     }
-                    Some(ok) => Some((ok, (events, false))),
+                    Some(ok) => Some((ok, (frames, false))),
                     None => None,
                 }
             },
         );
 
-        Ok(Box::pin(guarded))
+        Ok(Box::pin(bounded))
     }
 }
 

--- a/bmc-http/tests/event_stream_tests.rs
+++ b/bmc-http/tests/event_stream_tests.rs
@@ -36,6 +36,14 @@ mod tests {
         severity: String,
     }
 
+    struct WithoutHeader(&'static str);
+
+    impl Match for WithoutHeader {
+        fn matches(&self, request: &Request) -> bool {
+            !request.headers.contains_key(self.0)
+        }
+    }
+
     #[tokio::test]
     async fn test_event_stream_reads_typed_json() {
         let mock_server = MockServer::start().await;
@@ -416,14 +424,6 @@ mod tests {
 
     #[tokio::test]
     async fn an_empty_resume_id_is_no_resume_id() {
-        struct WithoutHeader(&'static str);
-
-        impl Match for WithoutHeader {
-            fn matches(&self, request: &Request) -> bool {
-                !request.headers.contains_key(self.0)
-            }
-        }
-
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -449,14 +449,6 @@ mod tests {
 
     #[tokio::test]
     async fn a_fresh_stream_sends_no_last_event_id() {
-        struct WithoutHeader(&'static str);
-
-        impl Match for WithoutHeader {
-            fn matches(&self, request: &Request) -> bool {
-                !request.headers.contains_key(self.0)
-            }
-        }
-
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))

--- a/bmc-http/tests/event_stream_tests.rs
+++ b/bmc-http/tests/event_stream_tests.rs
@@ -384,6 +384,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn the_resume_id_stays_in_effect_until_the_server_sets_another() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(SSE_URI))
+            .and(header("last-event-id", "7"))
+            .respond_with(sse_response(
+                "data: {\"n\":1}\n\nid: 8\ndata: {\"n\":2}\n\n",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let stream = bmc
+            .stream_events::<JsonValue>(SSE_URI, Some("7"))
+            .await
+            .expect("must open stream");
+        let events: Vec<_> = stream
+            .map(|event| event.expect("event parse"))
+            .collect()
+            .await;
+
+        let ids: Vec<Option<&str>> = events
+            .iter()
+            .map(|event| event.last_event_id.as_deref())
+            .collect();
+        assert_eq!(ids, [Some("7"), Some("8")]);
+    }
+
+    #[tokio::test]
+    async fn an_empty_resume_id_is_no_resume_id() {
+        struct WithoutHeader(&'static str);
+
+        impl Match for WithoutHeader {
+            fn matches(&self, request: &Request) -> bool {
+                !request.headers.contains_key(self.0)
+            }
+        }
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(SSE_URI))
+            .and(WithoutHeader("last-event-id"))
+            .respond_with(sse_response("data: {}\n\n"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let mut stream = bmc
+            .stream_events::<JsonValue>(SSE_URI, Some(""))
+            .await
+            .expect("must open stream");
+        let event = stream
+            .next()
+            .await
+            .expect("one event")
+            .expect("event parse");
+        assert_eq!(event.last_event_id, None);
+    }
+
+    #[tokio::test]
     async fn a_fresh_stream_sends_no_last_event_id() {
         struct WithoutHeader(&'static str);
 

--- a/bmc-http/tests/event_stream_tests.rs
+++ b/bmc-http/tests/event_stream_tests.rs
@@ -25,7 +25,7 @@ mod tests {
     use serde_json::Value as JsonValue;
     use wiremock::{
         matchers::{header, method, path},
-        Mock, MockServer, ResponseTemplate,
+        Match, Mock, MockServer, Request, ResponseTemplate,
     };
 
     const SSE_URI: &str = "/redfish/v1/EventService/SSE";
@@ -269,6 +269,165 @@ mod tests {
         let result = bmc
             .stream::<JsonValue>("https://bmc.example.evil/redfish/v1/EventService/SSE")
             .await;
+
+        assert!(matches!(result, Err(BmcError::InvalidRequest(_))));
+    }
+
+    fn sse_response(body: &str) -> ResponseTemplate {
+        ResponseTemplate::new(200)
+            .insert_header("content-type", "text/event-stream")
+            .set_body_string(body)
+    }
+
+    #[tokio::test]
+    async fn event_ids_are_carried_and_persist_until_the_server_changes_them() {
+        let mock_server = MockServer::start().await;
+        // The SSE processing model: an `id` field sets the last event id, a
+        // frame without one keeps it, an id-only frame moves it without
+        // dispatching an event, an `id` holding a NUL is ignored, and an
+        // empty `id` clears it.
+        let sse_body = concat!(
+            "id: 7\n",
+            "data: {\"n\":1}\n\n",
+            "data: {\"n\":2}\n\n",
+            "id: 9\n\n",
+            "data: {\"n\":3}\n\n",
+            "id: 9\u{0}x\n",
+            "data: {\"n\":4}\n\n",
+            "id: \n",
+            "data: {\"n\":5}\n\n"
+        );
+
+        Mock::given(method("GET"))
+            .and(path(SSE_URI))
+            .respond_with(sse_response(sse_body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let stream = bmc
+            .stream_events::<JsonValue>(SSE_URI, None)
+            .await
+            .expect("must open stream");
+        let events: Vec<_> = stream
+            .map(|event| event.expect("event parse"))
+            .collect()
+            .await;
+
+        let ids: Vec<Option<&str>> = events
+            .iter()
+            .map(|event| event.last_event_id.as_deref())
+            .collect();
+        assert_eq!(ids, [Some("7"), Some("7"), Some("9"), Some("9"), None]);
+        let payloads: Vec<u64> = events
+            .iter()
+            .map(|event| event.data["n"].as_u64().expect("a number"))
+            .collect();
+        assert_eq!(payloads, [1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn the_plain_stream_is_the_same_events_without_their_ids() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(SSE_URI))
+            .respond_with(sse_response(
+                "id: 7\ndata: {\"n\":1}\n\ndata: {\"n\":2}\n\n",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let stream = bmc
+            .stream::<JsonValue>(SSE_URI)
+            .await
+            .expect("must open stream");
+        let payloads: Vec<JsonValue> = stream
+            .map(|payload| payload.expect("event parse"))
+            .collect()
+            .await;
+
+        assert_eq!(
+            payloads,
+            [serde_json::json!({"n": 1}), serde_json::json!({"n": 2})]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_resumed_stream_sends_the_last_event_id() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(SSE_URI))
+            .and(header("last-event-id", "7"))
+            .respond_with(sse_response("id: 8\ndata: {}\n\n"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let mut stream = bmc
+            .stream_events::<JsonValue>(SSE_URI, Some("7"))
+            .await
+            .expect("must open stream");
+
+        let event = stream
+            .next()
+            .await
+            .expect("one event")
+            .expect("event parse");
+        assert_eq!(event.last_event_id.as_deref(), Some("8"));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_fresh_stream_sends_no_last_event_id() {
+        struct WithoutHeader(&'static str);
+
+        impl Match for WithoutHeader {
+            fn matches(&self, request: &Request) -> bool {
+                !request.headers.contains_key(self.0)
+            }
+        }
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(SSE_URI))
+            .and(WithoutHeader("last-event-id"))
+            .respond_with(sse_response("data: {}\n\n"))
+            .expect(2)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let mut stream = bmc
+            .stream_events::<JsonValue>(SSE_URI, None)
+            .await
+            .expect("must open stream");
+        let event = stream
+            .next()
+            .await
+            .expect("one event")
+            .expect("event parse");
+        assert_eq!(event.last_event_id, None);
+
+        let mut stream = bmc
+            .stream::<JsonValue>(SSE_URI)
+            .await
+            .expect("must open stream");
+        assert!(stream.next().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_last_event_id_that_is_not_a_header_value_is_rejected_before_transport() {
+        let mock_server = MockServer::start().await;
+        let bmc = create_test_bmc(&mock_server);
+
+        let result = bmc.stream_events::<JsonValue>(SSE_URI, Some("7\n8")).await;
 
         assert!(matches!(result, Err(BmcError::InvalidRequest(_))));
     }

--- a/bmc-http/tests/request_concurrency_tests.rs
+++ b/bmc-http/tests/request_concurrency_tests.rs
@@ -736,6 +736,36 @@ mod tests {
     }
 
     #[test]
+    fn stream_events_holds_the_permit_during_establishment_like_stream() {
+        let (client, mut transport) = controlled_client();
+        let bmc = create_bmc(client, NonZeroUsize::MIN, 0);
+        let next_id = ODataId::from("/next".to_owned());
+
+        let mut sse = tokio_test::task::spawn(bmc.stream_events::<JsonValue>(SSE_URI, None));
+
+        assert!(matches!(sse.poll(), Poll::Pending));
+        let sse_attempt = transport.next_attempt();
+
+        assert_eq!(sse_attempt.path, SSE_URI);
+
+        let mut next = tokio_test::task::spawn(bmc.get::<TestResource>(&next_id));
+        assert_pending!(next.poll());
+        transport.assert_no_attempt();
+
+        respond(sse_attempt, TestResponse::SseEstablished);
+
+        let _stream = assert_ready_ok!(sse.poll());
+
+        assert!(next.is_woken());
+        assert_pending!(next.poll());
+        let next_attempt = transport.next_attempt();
+
+        assert_eq!(next_attempt.path, "/next");
+        respond(next_attempt, TestResponse::Resource(None));
+        assert_ready_ok!(next.poll());
+    }
+
+    #[test]
     fn omitted_limit_preserves_unlimited_transport_entry() {
         let (client, mut transport) = controlled_client();
 

--- a/bmc-mock/src/expect.rs
+++ b/bmc-mock/src/expect.rs
@@ -22,6 +22,7 @@ use nv_redfish_core::AsyncTask;
 use nv_redfish_core::ODataId;
 
 use serde_json::from_str;
+use serde_json::json;
 use serde_json::Value as JsonValue;
 
 pub type Response<E> = Result<JsonValue, E>;
@@ -95,6 +96,13 @@ pub enum ExpectedRequest {
 
     /// Expected Stream.
     Stream { uri: String },
+
+    /// Expected stream opened with this `Last-Event-ID`, answered with
+    /// events that carry ids.
+    StreamEvents {
+        uri: String,
+        last_event_id: Option<String>,
+    },
 }
 
 /// Expectation for the tests.
@@ -278,12 +286,36 @@ impl<E> Expect<E> {
         }
     }
 
+    /// A stream of `response`, a JSON array of payloads. It serves `stream`,
+    /// and `stream_events` opened without a `Last-Event-ID`, whose events
+    /// then carry no id.
     pub fn stream(uri: impl Display, response: impl Display) -> Self {
         Expect {
             request: ExpectedRequest::Stream {
                 uri: uri.to_string(),
             },
             response: Ok(from_str(&response.to_string()).expect("invalid json")),
+        }
+    }
+
+    /// A stream opened with `last_event_id`, delivering `events` as pairs of
+    /// the id the client sees on the event and the payload. It serves
+    /// `stream_events` asked for that id, and `stream` when the id is `None`.
+    pub fn stream_events<'a>(
+        uri: impl Display,
+        last_event_id: Option<&str>,
+        events: impl IntoIterator<Item = (Option<&'a str>, JsonValue)>,
+    ) -> Self {
+        let events = events
+            .into_iter()
+            .map(|(id, data)| json!({ "last_event_id": id, "data": data }))
+            .collect();
+        Expect {
+            request: ExpectedRequest::StreamEvents {
+                uri: uri.to_string(),
+                last_event_id: last_event_id.map(str::to_owned),
+            },
+            response: Ok(JsonValue::Array(events)),
         }
     }
 }

--- a/bmc-mock/src/lib.rs
+++ b/bmc-mock/src/lib.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::PoisonError;
 
+use futures_util::TryStreamExt as _;
 use nv_redfish_core::action::ActionTarget;
 use nv_redfish_core::query::ExpandQuery;
 use nv_redfish_core::ActionError;
@@ -41,6 +42,7 @@ use nv_redfish_core::MultipartUpdateRequest;
 use nv_redfish_core::ODataETag;
 use nv_redfish_core::ODataId;
 use nv_redfish_core::SessionCreateResponse;
+use nv_redfish_core::StreamEvent;
 use nv_redfish_core::UploadReader;
 use serde::Serialize;
 use serde_json::from_value;
@@ -502,6 +504,15 @@ where
         &self,
         in_uri: &str,
     ) -> Result<nv_redfish_core::BoxTryStream<T, Self::Error>, Self::Error> {
+        let events = self.stream_events::<T>(in_uri, None).await?;
+        Ok(Box::pin(events.map_ok(|event| event.data)))
+    }
+
+    async fn stream_events<T: Sized + for<'de> serde::Deserialize<'de> + Send + 'static>(
+        &self,
+        in_uri: &str,
+        last_event_id: Option<&str>,
+    ) -> Result<nv_redfish_core::BoxTryStream<StreamEvent<T>, Self::Error>, Self::Error> {
         let expect = self
             .expect
             .lock()
@@ -512,16 +523,48 @@ where
             Expect {
                 request: ExpectedRequest::Stream { uri },
                 response,
-            } if uri == *in_uri => {
+            } if uri == *in_uri && last_event_id.is_none() => {
                 let response = response.map_err(|err| Error::ErrorResponse(Box::new(err)))?;
-                let result: Vec<T> = from_value(response).map_err(Error::BadResponseJson)?;
-                Ok(Box::pin(futures_util::stream::iter(
-                    result.into_iter().map(Ok),
-                )))
+                let payloads: Vec<T> = from_value(response).map_err(Error::BadResponseJson)?;
+                let events = payloads.into_iter().map(|data| StreamEvent {
+                    last_event_id: None,
+                    data,
+                });
+                Ok(Box::pin(futures_util::stream::iter(events.map(Ok))))
             }
-            _ => Err(Error::UnexpectedStream(in_uri.to_string(), expect.request)),
+            Expect {
+                request:
+                    ExpectedRequest::StreamEvents {
+                        uri,
+                        last_event_id: expected,
+                    },
+                response,
+            } if uri == *in_uri && expected.as_deref() == last_event_id => {
+                let response = response.map_err(|err| Error::ErrorResponse(Box::new(err)))?;
+                let events: Vec<ScriptedEvent<T>> =
+                    from_value(response).map_err(Error::BadResponseJson)?;
+                let events = events.into_iter().map(|event| StreamEvent {
+                    last_event_id: event.last_event_id,
+                    data: event.data,
+                });
+                Ok(Box::pin(futures_util::stream::iter(events.map(Ok))))
+            }
+            _ => {
+                let request = match last_event_id {
+                    Some(id) => format!("{in_uri} resumed after {id:?}"),
+                    None => in_uri.to_string(),
+                };
+                Err(Error::UnexpectedStream(request, expect.request))
+            }
         }
     }
+}
+
+/// One event as [`Expect::stream_events`] scripts it.
+#[derive(serde::Deserialize)]
+struct ScriptedEvent<T> {
+    last_event_id: Option<String>,
+    data: T,
 }
 
 impl ActionError for Error {

--- a/core/src/bmc.rs
+++ b/core/src/bmc.rs
@@ -217,8 +217,9 @@ pub trait Bmc: Send + Sync {
     /// the event's `data` decoded into `T`, with the event id in effect.
     /// `last_event_id` is the id a consumer kept from an earlier stream of
     /// the same URI, sent as `Last-Event-ID` so a server that retains
-    /// history replays the events after it; `None` starts at the server's
-    /// live position.
+    /// history replays the events after it, and in effect on the new stream
+    /// until the server sets another; `None`, or an empty id, starts at the
+    /// server's live position.
     ///
     /// The default forwards to [`Bmc::stream`]: its events carry no id and
     /// nothing is sent to resume from, which cannot mislead a consumer, since

--- a/core/src/bmc.rs
+++ b/core/src/bmc.rs
@@ -66,7 +66,12 @@ use crate::ODataId;
 use crate::SessionCreateResponse;
 use std::error::Error as StdError;
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+
+use futures_core::Stream;
 
 use crate::MultipartUpdateRequest;
 use crate::UploadReader;
@@ -204,4 +209,117 @@ pub trait Bmc: Send + Sync {
         &self,
         uri: &str,
     ) -> impl Future<Output = Result<BoxTryStream<T, Self::Error>, Self::Error>> + Send;
+
+    /// Stream server-sent events from the URI with the id each carries,
+    /// resuming after `last_event_id`.
+    ///
+    /// Same URI rules as [`Bmc::stream`]. Every item is a [`StreamEvent`]:
+    /// the event's `data` decoded into `T`, with the event id in effect.
+    /// `last_event_id` is the id a consumer kept from an earlier stream of
+    /// the same URI, sent as `Last-Event-ID` so a server that retains
+    /// history replays the events after it; `None` starts at the server's
+    /// live position.
+    ///
+    /// The default forwards to [`Bmc::stream`]: its events carry no id and
+    /// nothing is sent to resume from, which cannot mislead a consumer, since
+    /// it only ever holds an id this method gave it. A transport that
+    /// surfaces SSE ids overrides it.
+    fn stream_events<T: Sized + for<'de> Deserialize<'de> + Send + 'static>(
+        &self,
+        uri: &str,
+        last_event_id: Option<&str>,
+    ) -> impl Future<Output = Result<BoxTryStream<StreamEvent<T>, Self::Error>, Self::Error>> + Send
+    where
+        Self::Error: 'static,
+    {
+        let _ = last_event_id;
+        async move { self.stream::<T>(uri).await.map(without_event_ids) }
+    }
+}
+
+/// One event a server-sent event stream delivered.
+///
+/// `data` is the event's payload, decoded into the type the stream was
+/// opened with. `last_event_id` is the SSE `id` in effect when the event was
+/// dispatched: a server sets it per event, it persists over later events
+/// that carry none, and an `id` field with an empty value clears it, as the
+/// SSE processing model prescribes. A consumer that reopens the stream hands
+/// it back through [`Bmc::stream_events`] to resume after this event. A
+/// server that never sets one, or a transport that does not surface ids,
+/// leaves it `None` throughout.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamEvent<T> {
+    /// The id to resume after this event, if the server set one.
+    pub last_event_id: Option<String>,
+    /// The event's decoded payload.
+    pub data: T,
+}
+
+/// `stream` as a stream of [`StreamEvent`]s that carry no id: the view a
+/// transport that does not surface SSE ids gives through
+/// [`Bmc::stream_events`].
+#[must_use]
+pub fn without_event_ids<T, E>(stream: BoxTryStream<T, E>) -> BoxTryStream<StreamEvent<T>, E>
+where
+    T: 'static,
+    E: 'static,
+{
+    Box::pin(WithoutEventIds(stream))
+}
+
+struct WithoutEventIds<T, E>(BoxTryStream<T, E>);
+
+impl<T, E> Stream for WithoutEventIds<T, E> {
+    type Item = Result<StreamEvent<T>, E>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.0.as_mut().poll_next(cx).map(|item| {
+            item.map(|result| {
+                result.map(|data| StreamEvent {
+                    last_event_id: None,
+                    data,
+                })
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::task::Waker;
+    use std::vec::IntoIter;
+
+    use super::*;
+
+    /// A stream over a fixed list of items.
+    struct Items(IntoIter<Result<u8, &'static str>>);
+
+    impl Stream for Items {
+        type Item = Result<u8, &'static str>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.0.next())
+        }
+    }
+
+    #[test]
+    fn without_ids_keeps_items_and_errors_and_attaches_no_id() {
+        let items = Items(vec![Ok(1), Err("lost"), Ok(2)].into_iter());
+        let mut events = without_event_ids(Box::pin(items));
+        let mut cx = Context::from_waker(Waker::noop());
+        let event = |data| {
+            Poll::Ready(Some(Ok(StreamEvent {
+                last_event_id: None,
+                data,
+            })))
+        };
+
+        assert_eq!(events.as_mut().poll_next(&mut cx), event(1));
+        assert_eq!(
+            events.as_mut().poll_next(&mut cx),
+            Poll::Ready(Some(Err("lost")))
+        );
+        assert_eq!(events.as_mut().poll_next(&mut cx), event(2));
+        assert_eq!(events.as_mut().poll_next(&mut cx), Poll::Ready(None));
+    }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -99,7 +99,11 @@ pub use action::Action;
 #[doc(inline)]
 pub use action::ActionError;
 #[doc(inline)]
+pub use bmc::without_event_ids;
+#[doc(inline)]
 pub use bmc::Bmc;
+#[doc(inline)]
+pub use bmc::StreamEvent;
 #[doc(inline)]
 pub use deserialize::de_optional_nullable;
 #[doc(inline)]

--- a/redfish/src/event_service/mod.rs
+++ b/redfish/src/event_service/mod.rs
@@ -31,6 +31,7 @@ use futures_util::TryStreamExt as _;
 use nv_redfish_core::odata::ODataType;
 use nv_redfish_core::Bmc;
 use nv_redfish_core::BoxTryStream;
+use nv_redfish_core::StreamEvent;
 use serde::de;
 use serde::Deserialize;
 use serde::Deserializer;
@@ -154,6 +155,31 @@ impl<B: Bmc> EventService<B> {
         B: 'static,
         B::Error: 'static,
     {
+        let events = self.events_from(None).await?;
+        Ok(Box::pin(events.map_ok(|event| event.data)))
+    }
+
+    /// Open an SSE stream of Redfish event payloads with the id each carries,
+    /// resuming after `last_event_id`.
+    ///
+    /// Payloads are decoded as by [`EventService::events`]. Each item is a
+    /// [`StreamEvent`] with the event id in effect, which a consumer that lost
+    /// the stream passes back here to resume after the last payload it
+    /// handled; `None` starts at the device's live position. A transport that
+    /// does not surface event ids yields `None` for every id and cannot
+    /// resume.
+    ///
+    /// # Errors
+    ///
+    /// As [`EventService::events`].
+    pub async fn events_from(
+        &self,
+        last_event_id: Option<&str>,
+    ) -> Result<BoxTryStream<StreamEvent<EventStreamPayload>, Error<B>>, Error<B>>
+    where
+        B: 'static,
+        B::Error: 'static,
+    {
         let stream_uri = self
             .data
             .server_sent_event_uri
@@ -163,18 +189,25 @@ impl<B: Bmc> EventService<B> {
         let stream = self
             .bmc
             .as_ref()
-            .stream::<JsonValue>(stream_uri)
+            .stream_events::<JsonValue>(stream_uri, last_event_id)
             .await
             .map_err(Error::Bmc)?;
 
         let sse_read_patches = self.sse_read_patches.clone();
-        let stream = stream.map_err(Error::Bmc).and_then(move |payload| {
-            let patched = sse_read_patches
-                .iter()
-                .fold(payload, |acc, patch| patch(acc));
+        let stream = stream.map_err(Error::Bmc).and_then(move |event| {
+            let StreamEvent {
+                last_event_id,
+                data,
+            } = event;
+            let patched = sse_read_patches.iter().fold(data, |acc, patch| patch(acc));
 
             future::ready(
-                serde_json::from_value::<EventStreamPayload>(patched).map_err(Error::Json),
+                serde_json::from_value::<EventStreamPayload>(patched)
+                    .map(|data| StreamEvent {
+                        last_event_id,
+                        data,
+                    })
+                    .map_err(Error::Json),
             )
         });
 

--- a/redfish/src/lib.rs
+++ b/redfish/src/lib.rs
@@ -190,6 +190,8 @@ pub use error::Error;
 #[doc(inline)]
 pub use nv_redfish_core::Bmc;
 #[doc(inline)]
+pub use nv_redfish_core::StreamEvent;
+#[doc(inline)]
 pub use protocol_features::ProtocolFeatures;
 #[doc(inline)]
 pub use resource::Resource;

--- a/tests/tests/test-event-service-resume.rs
+++ b/tests/tests/test-event-service-resume.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! An EventService stream resumed by event id: the id the request resumes
+//! after and the id each event carries travel through the wrapper unchanged,
+//! and the plain stream stays what it was.
+
+use std::error::Error as StdError;
+use std::sync::Arc;
+
+use futures_util::TryStreamExt as _;
+use nv_redfish::event_service::EventService;
+use nv_redfish::event_service::EventStreamPayload;
+use nv_redfish::ServiceRoot;
+use nv_redfish_core::ODataId;
+use nv_redfish_tests::Bmc;
+use nv_redfish_tests::Expect;
+use nv_redfish_tests::ODATA_ID;
+use nv_redfish_tests::ODATA_TYPE;
+use serde_json::json;
+use serde_json::Value;
+use tokio::test;
+
+const SERVICE_ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_13_0.ServiceRoot";
+const EVENT_SERVICE_DATA_TYPE: &str = "#EventService.v1_9_3.EventService";
+const EVENT_DATA_TYPE: &str = "#Event.v1_9_2.Event";
+const EVENT_SERVICE_ID: &str = "/redfish/v1/EventService";
+const SSE_URI: &str = "/redfish/v1/EventService/SSE";
+
+#[test]
+async fn a_resumed_event_stream_carries_each_events_id() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let event_service = open_event_service(&bmc).await?;
+
+    // Asked for the events after 41, the device answers event 42; the mock
+    // holds the request to that id.
+    bmc.expect(Expect::stream_events(
+        SSE_URI,
+        Some("41"),
+        [(Some("42"), event(42))],
+    ));
+    let mut events = event_service.events_from(Some("41")).await?;
+    let resumed = events.try_next().await?.expect("one event");
+    assert_eq!(resumed.last_event_id.as_deref(), Some("42"));
+    assert!(matches!(resumed.data, EventStreamPayload::Event(_)));
+    assert!(events.try_next().await?.is_none());
+
+    // The plain stream opens without an id and yields the payloads alone.
+    bmc.expect(Expect::stream(SSE_URI, json!([event(43)])));
+    let mut payloads = event_service.events().await?;
+    assert!(matches!(
+        payloads.try_next().await?,
+        Some(EventStreamPayload::Event(_))
+    ));
+    assert!(payloads.try_next().await?.is_none());
+
+    Ok(())
+}
+
+#[test]
+async fn a_stream_expectation_holds_the_request_to_its_id() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let event_service = open_event_service(&bmc).await?;
+
+    bmc.expect(Expect::stream_events(
+        SSE_URI,
+        Some("41"),
+        [(Some("42"), event(42))],
+    ));
+    let Err(error) = event_service.events_from(Some("40")).await else {
+        panic!("the mock holds the request to the scripted id");
+    };
+
+    // The message names both the id asked for and the one scripted.
+    let error = error.to_string();
+    assert!(error.contains("unexpected stream"), "{}", error);
+    assert!(error.contains("resumed after \"40\""), "{}", error);
+    assert!(error.contains("Some(\"41\")"), "{}", error);
+
+    Ok(())
+}
+
+async fn open_event_service(bmc: &Arc<Bmc>) -> Result<EventService<Bmc>, Box<dyn StdError>> {
+    let root_id = ODataId::service_root();
+    bmc.expect(Expect::get(&root_id, service_root(&root_id)));
+    let service_root = ServiceRoot::new(bmc.clone()).await?;
+
+    bmc.expect(Expect::get(EVENT_SERVICE_ID, event_service()));
+    Ok(service_root
+        .event_service()
+        .await?
+        .expect("service root advertises an EventService"))
+}
+
+fn service_root(root_id: &ODataId) -> Value {
+    json!({
+        ODATA_ID: root_id,
+        ODATA_TYPE: SERVICE_ROOT_DATA_TYPE,
+        "Id": "RootService",
+        "Name": "RootService",
+        "EventService": { ODATA_ID: EVENT_SERVICE_ID },
+        "Links": {
+            "Sessions": { ODATA_ID: format!("{root_id}/SessionService/Sessions") }
+        },
+    })
+}
+
+fn event_service() -> Value {
+    json!({
+        ODATA_ID: EVENT_SERVICE_ID,
+        ODATA_TYPE: EVENT_SERVICE_DATA_TYPE,
+        "Id": "EventService",
+        "Name": "Event Service",
+        "ServerSentEventUri": SSE_URI,
+    })
+}
+
+fn event(id: u32) -> Value {
+    json!({
+        ODATA_ID: format!("{SSE_URI}#/Event{id}"),
+        ODATA_TYPE: EVENT_DATA_TYPE,
+        "Id": id.to_string(),
+        "Name": "Event Array",
+        "Events": [{
+            "MemberId": "0",
+            "EventType": "Alert",
+            "EventId": id.to_string(),
+            "MessageId": "Example.1.0.TestEvent",
+        }],
+    })
+}


### PR DESCRIPTION
Before API did not allowed to resume SSE streams fron the last seen id. This PR adds api `sse_events` which allows to supply this information. 

This is non breaking change (hence new function)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Server-Sent Event streams with event ID tracking and resumption from a specified event ID.
  - Added Event Service APIs for resuming streams from a selected event.
  - Preserved compatibility with streams that do not include event IDs.
  - Added mock stream support for scripted events and resumption scenarios.

- **Bug Fixes**
  - Improved SSE frame handling, timeout behavior, and error processing.
  - Ensured event stream requests honor concurrency limits during connection setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->